### PR TITLE
Fix Counter accepting rollover values less than or equal to zero, enf…

### DIFF
--- a/src/main/scala/Chisel/util/Counter.scala
+++ b/src/main/scala/Chisel/util/Counter.scala
@@ -7,6 +7,7 @@ package Chisel
   * maximum output value of the counter), need not be a power of two
   */
 class Counter(val n: Int) {
+  require(n > 0)
   val value = if (n == 1) UInt(0) else Reg(init=UInt(0, log2Up(n)))
   /** Increment the counter, returning whether the counter currently is at the
     * maximum and will wrap. The incremented value is registered and will be

--- a/src/test/scala/chiselTests/Counter.scala
+++ b/src/test/scala/chiselTests/Counter.scala
@@ -41,7 +41,9 @@ class CounterSpec extends ChiselPropSpec {
   }
 
   property("Counter can be en/disabled") {
-    forAll(safeUInts) { (seed: Int) => assertTesterPasses{ new EnableTester(seed) } }
+    forAll(safeUInts) { (seed: Int) =>
+      whenever(seed > 0) { assertTesterPasses{ new EnableTester(seed) } }
+    }
   }
 
   property("Counter should wrap") {


### PR DESCRIPTION
…orce >0 in Counter tests

Given n is defined as "number of counts before the counter resets (or one more than the maximum output value of the counter)", it makes sense that n must be strictly positive.