### PR TITLE
Elaborate a literal UInt(0) with 0-width

### DIFF
--- a/src/test/scala/chiselTests/Width.scala
+++ b/src/test/scala/chiselTests/Width.scala
@@ -1,0 +1,20 @@
+// See LICENSE for license details.
+
+package chiselTests
+import Chisel._
+import org.scalatest._
+import Chisel.testers.BasicTester
+
+class ZeroWidthUInt extends Module {
+  val io = new Bundle {
+  }
+
+  UInt(0, width = 0)
+}
+
+class WidthSpec extends ChiselPropSpec with Matchers {
+  property("The literal 0 has a width of 0") {
+    elaborate(new ZeroWidthUInt)
+  }
+}
+


### PR DESCRIPTION
I'm not sure if this test should or shouldn't pass, but it currently
fails and requires the following workaround

  https://github.com/ucb-bar/uncore/commit/a5a23b6c16a64ce14ebc15908d91ce5f69d5236a

before merging the related PR

  https://github.com/ucb-bar/uncore/pull/19

I'd like to know if this is actually a bug.