### PR TITLE
Add globalReset to stop assertions from firing in sim reset

### DIFF
--- a/src/main/resources/top.cpp
+++ b/src/main/resources/top.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
   cout << "Starting simulation!\n";
 
   while (!Verilated::gotFinish() && main_time < timeout) {
-    if (main_time > 10) {
+    if (main_time > 40) {
       top->reset = 0;   // Deassert reset
     }
     if ((main_time % 10) == 1) {

--- a/src/main/scala/Chisel/CoreUtil.scala
+++ b/src/main/scala/Chisel/CoreUtil.scala
@@ -48,7 +48,8 @@ object assert {
   }
 
   def apply_impl_do(cond: Bool, line: String, message: Option[String]) {
-    when (!Builder.dynamicContext.currentModule.get.reset) {
+    when (!Builder.dynamicContext.currentModule.get.reset &&
+          !Builder.dynamicContext.currentModule.get.globalReset ) {
       when(!cond) {
         message match {
           case Some(str) => printf(s"Assertion failed: $str\n    at $line\n")


### PR DESCRIPTION
Fix for #121 

Add a global reset that is passed throughout the circuit and is checked in conditions for assertions. 

For this to work, simulations must drive reset high at the top-level for long enough that all local resets are driven high. 

Feedback would be appreciated. 