### PR TITLE
Bump plugin versions.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,10 +6,10 @@ resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.2")


### PR DESCRIPTION
Scalastyle "scalastyle-sbt-plugin" % "0.7.0) dies with:
    [error] .../chisel3/src/main/scala/Chisel/Data.scala: Expected token RBRACKET but got Token(XML_START_OPEN,<,4360,<)
    [error] .../chisel3/src/main/scala/Chisel/Driver.scala: Expected token RBRACKET but got Token(XML_START_OPEN,<,3418,<)
    ...
Upgrade to "scalastyle-sbt-plugin" % "0.8.0"
(and bump the the others to "current" versions while we're here.)