### PR TITLE
Add Arch Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ This will walk you through installing Chisel and its dependencies:
     sudo make install
     ```
 
+### Arch Linux
+    ```
+    yaourt -S firrtl-git verilator sbt
+    ```
+
 ### Windows
 
 *TODO: write me. If you __really__ want to see this happen, let us know by filing a bug report!*


### PR DESCRIPTION
Hi,

this adds installation instructions for Chisel3's dependencies on Arch Linux.

It was tested by running "sbt test".