### PR TITLE
Make Wire(init = x) behave the same as Wire(t = x) := x

### DIFF
--- a/src/main/scala/Chisel/Aggregate.scala
+++ b/src/main/scala/Chisel/Aggregate.scala
@@ -46,8 +46,7 @@ object Vec {
 
     require(!elts.isEmpty)
     val width = elts.map(_.width).reduce(_ max _)
-    val vec = new Vec(elts.head.cloneTypeWidth(width), elts.length)
-    pushCommand(DefWire(vec))
+    val vec = Wire(new Vec(elts.head.cloneTypeWidth(width), elts.length))
     for ((v, e) <- vec zip elts)
       v := e
     vec

--- a/src/main/scala/Chisel/Data.scala
+++ b/src/main/scala/Chisel/Data.scala
@@ -123,11 +123,9 @@ object Wire {
   private def makeWire[T <: Data](t: T, init: T): T = {
     val x = Reg.makeType(t, null.asInstanceOf[T], init)
     pushCommand(DefWire(x))
-    if (init != null) {
+    pushCommand(DefInvalid(x.ref))
+    if (init != null)
       x := init
-    } else {
-      pushCommand(DefInvalid(x.ref))
-    }
     x
   }
 }


### PR DESCRIPTION
There's a separate debate to be had about whether we want to
default-initialize Wires to invalid.  This patch just fixes the
implementation of the previous, unsafe approach, which was usually,
but not always, defaulting to invalid.