### PR TITLE
Assert message causes firrtl quote parsing error - issue #111

### DIFF
--- a/src/test/scala/chiselTests/AssertQuoteProblem.scala
+++ b/src/test/scala/chiselTests/AssertQuoteProblem.scala
@@ -5,7 +5,7 @@ package chiselTests
 import Chisel._
 import Chisel.testers.BasicTester
 
-/** This llustrates a problem, where the string second
+/** This illustrates a problem, where the string second
   * argument to Chisel.assert causes a firrtl error
   */
 class QuoteProblemCircuit extends Module {
@@ -31,7 +31,7 @@ class QuoteProblemTests extends BasicTester {
 }
 class QuoteProblemTester extends ChiselFlatSpec {
   "QuoteProblem" should "compile and run without incident" in {
-    assertTesterPasses { new QuoteProblemTests }
+    assertTesterFails { new QuoteProblemTests }
   }
 }
 

--- a/src/test/scala/chiselTests/AssertQuoteProblem.scala
+++ b/src/test/scala/chiselTests/AssertQuoteProblem.scala
@@ -30,7 +30,7 @@ class QuoteProblemTests extends BasicTester {
   }
 }
 class QuoteProblemTester extends ChiselFlatSpec {
-  "QuoteProblem" should "compile and run without incident" in {
+  "QuoteProblem" should "fail with \"Assertion failed: This better be the answer\"" in {
     assertTesterFails { new QuoteProblemTests }
   }
 }

--- a/src/test/scala/chiselTests/AssertQuoteProblem.scala
+++ b/src/test/scala/chiselTests/AssertQuoteProblem.scala
@@ -1,0 +1,37 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import Chisel._
+import Chisel.testers.BasicTester
+
+/** This llustrates a problem, where the string second
+  * argument to Chisel.assert causes a firrtl error
+  */
+class QuoteProblemCircuit extends Module {
+  val w = 32
+  val magic_number = 42
+  val io = new Bundle {
+    val out = UInt(OUTPUT, w)
+  }
+  io.out := UInt(magic_number)
+}
+
+class QuoteProblemTests extends BasicTester {
+  val device_under_test = Module( new QuoteProblemCircuit  )
+  val c = device_under_test
+
+  when(Bool(true)) {
+    /*
+    The assert statement here creates a complex printf with escaped quotes
+    which scala firrtl's parser does not seem to be able to handle.
+     */
+    assert(Bool(false), "This better be the answer")
+  }
+}
+class QuoteProblemTester extends ChiselFlatSpec {
+  "QuoteProblem" should "compile and run without incident" in {
+    assertTesterPasses { new QuoteProblemTests }
+  }
+}
+

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -17,6 +17,9 @@ trait ChiselRunners extends Assertions {
   def assertTesterPasses(t: => BasicTester, additionalVResources: Seq[String] = Seq()): Unit = {
     assert(runTester(t, additionalVResources))
   }
+  def assertTesterFails(t: => BasicTester, additionalVResources: Seq[String] = Seq()): Unit = {
+    assert(!runTester(t, additionalVResources))
+  }
   def elaborate(t: => Module): Unit = Driver.elaborate(() => t)
 
 }


### PR DESCRIPTION
The bug discovered by the initial issue (#111) has been fixed, so this issue may be closed (and this branch deleted). The most recent changes add an assertTesterFails() to the ChiselSpec and use the new method in the test.