### PR TITLE
Only elaborate once in chiselMain.run()

### DIFF
--- a/src/main/scala/Chisel/Main.scala
+++ b/src/main/scala/Chisel/Main.scala
@@ -9,9 +9,9 @@ import java.io.File
     Predef.assert(false)
 
   def run[T <: Module] (args: Array[String], gen: () => T): Unit = {
-    def circuit = Driver.elaborate(gen)
-    def output_file = new File(Driver.targetDir + "/" + circuit.name + ".fir")
+    val circuit = Driver.elaborate(gen)
     Driver.parseArgs(args)
+    val output_file = new File(Driver.targetDir + "/" + circuit.name + ".fir")
     Driver.dumpFirrtl(circuit, Option(output_file))
   }
 }


### PR DESCRIPTION
I'm not sure what I was doing, but I had a def instead of a val that was
causing the circuit to be elaborated twice.  When fixing this I changed
output_file to a val as well, but that throws a None.get exception.  I
don't understand why.