### PR TITLE
Add HasId=Module|Data.suggestName, TransitName util

### DIFF
--- a/src/main/scala/Chisel/util/Decoupled.scala
+++ b/src/main/scala/Chisel/util/Decoupled.scala
@@ -175,6 +175,6 @@ object Queue
     q.io.enq.valid := enq.valid // not using <> so that override is allowed
     q.io.enq.bits := enq.bits
     enq.ready := q.io.enq.ready
-    q.io.deq
+    TransitName(q.io.deq, q)
   }
 }

--- a/src/main/scala/Chisel/util/TransitName.scala
+++ b/src/main/scala/Chisel/util/TransitName.scala
@@ -1,0 +1,21 @@
+package Chisel
+
+import internal.HasId
+
+object TransitName {
+  // The purpose of this is to allow a library to 'move' a name call to a more
+  // appropriate place.
+  // For example, a library factory function may create a module and return
+  // the io. The only user-exposed field is that given IO, which can't use
+  // any name supplied by the user. This can add a hook so that the supplied
+  // name then names the Module.
+  // See Queue companion object for working example
+  def apply[T<:HasId](from: T, to: HasId): T = {
+    from.addPostnameHook((given_name: String) => {to.suggestName(given_name)})
+    from
+  }
+  def withSuffix[T<:HasId](suffix: String)(from: T, to: HasId): T = {
+    from.addPostnameHook((given_name: String) => {to.suggestName(given_name+suffix)})
+    from
+  }
+}


### PR DESCRIPTION
Often times the scala runtime reflection fails to find an appropriate
name for a given net. This commit tries to partially ameliorate the
issue by exposing a suggestName function onto HasId (i.e. Module, Data)
that the user can call to 'suggest' a name.

Only the first suggestion is taken so repeated calls to suggestName will
not change the name for that node. This type of name exposure is
slightly risky as there is a chance the same name is suggested in the
same namespace. Thus, naming within a Module occurs in two passes:

The suggestion phase is when the user calls suggestName, etc. Near the
'end,' the Module uses runtime reflection to suggest names as well.
The forcing phase is when all the nodes are run through and a name is
'forced' onto them, using the namespace to suggest alternatives if the
desired one is taken. If no suggestion is present, the default name is
T, as before.

Second, there is an issue that commonly comes up when a component
library creates intermediate logic and then only returns a piece, or
even a piece of a piece (like part of a module IO). Any names suggested
by the Module by reflection onto that return value are either lost or
not fully applied. This issue is resolved by TransitName. TransitName
attaches a hook to the suggestName function of a HasId. With that hook,
any time suggestName is called on the hooked ID, that name suggestion is
also applied to other nodes.

For example, if Queue(in) is called, then any attempts to name the
returned output DecoupledIO will actually translate to naming attempts
on the backing Queue.