### PR TITLE
Sketch Implementation of SourceInfo (do not merge)

### DIFF
--- a/src/main/scala/Chisel/Aggregate.scala
+++ b/src/main/scala/Chisel/Aggregate.scala
@@ -46,7 +46,7 @@ object Vec {
 
     require(!elts.isEmpty)
     val width = elts.map(_.width).reduce(_ max _)
-    val vec = Wire(new Vec(elts.head.cloneTypeWidth(width), elts.length))
+    val vec = Wire(new Vec(elts.head.cloneTypeWidth(width), elts.length))(SourceInfo(None))
     for ((v, e) <- vec zip elts)
       v := e
     vec

--- a/src/main/scala/Chisel/Bits.scala
+++ b/src/main/scala/Chisel/Bits.scala
@@ -198,7 +198,7 @@ sealed abstract class Bits(dirArg: Direction, width: Width, override val litArg:
   override def toBits: UInt = asUInt
 
   override def fromBits(n: Bits): this.type = {
-    val res = Wire(this).asInstanceOf[this.type]
+    val res = Wire(this)(SourceInfo(None)).asInstanceOf[this.type]
     res := n
     res
   }

--- a/src/main/scala/Chisel/Data.scala
+++ b/src/main/scala/Chisel/Data.scala
@@ -92,12 +92,12 @@ abstract class Data(dirArg: Direction) extends HasId {
     */
   def fromBits(n: Bits): this.type = {
     var i = 0
-    val wire = Wire(this.cloneType)
+    val wire = Wire(this.cloneType)(SourceInfo(None))
     val bits =
       if (n.width.known && n.width.get >= wire.width.get) {
         n
       } else {
-        Wire(n.cloneTypeWidth(wire.width), init = n)
+        Wire(n.cloneTypeWidth(wire.width), init = n)(SourceInfo(None))
       }
     for (x <- wire.flatten) {
       x := bits(i + x.getWidth-1, i)
@@ -114,16 +114,17 @@ abstract class Data(dirArg: Direction) extends HasId {
 }
 
 object Wire {
-  def apply[T <: Data](t: T): T =
-    makeWire(t, null.asInstanceOf[T])
+  def apply[T <: Data](t: T)(implicit info: SourceInfo): T =
+    makeWire(t, null.asInstanceOf[T], info)
 
-  def apply[T <: Data](dummy: Int = 0, init: T): T =
-    makeWire(null.asInstanceOf[T], init)
+  def apply[T <: Data](dummy: Int = 0, init: T)(implicit info: SourceInfo): T =
+    makeWire(null.asInstanceOf[T], init, info)
 
-  def apply[T <: Data](t: T, init: T): T =
-    makeWire(t, init)
+  def apply[T <: Data](t: T, init: T)(implicit info: SourceInfo): T =
+    makeWire(t, init, info)
 
-  private def makeWire[T <: Data](t: T, init: T): T = {
+  private def makeWire[T <: Data](t: T, init: T, info: SourceInfo): T = {
+    // TODO: Add SourceInfo to DefWire
     val x = Reg.makeType(t, null.asInstanceOf[T], init)
     pushCommand(DefWire(x))
     pushCommand(DefInvalid(x.ref))

--- a/src/main/scala/Chisel/Mem.scala
+++ b/src/main/scala/Chisel/Mem.scala
@@ -116,7 +116,7 @@ object SeqMem {
   */
 sealed class SeqMem[T <: Data](t: T, n: Int) extends MemBase[T](t, n) {
   def read(addr: UInt, enable: Bool): T = {
-    val a = Wire(UInt())
+    val a = Wire(UInt())(SourceInfo(None))
     when (enable) { a := addr }
     read(a)
   }

--- a/src/main/scala/Chisel/SourceInfo.scala
+++ b/src/main/scala/Chisel/SourceInfo.scala
@@ -1,0 +1,32 @@
+package Chisel
+
+import scala.language.experimental.macros
+
+// A box around the details
+// Nervous about having an implicit Option[_] in case of implicit None
+case class SourceInfo(sinfo: Option[SourceInfo.SourceLoc])
+object SourceInfo {
+  sealed trait SourceLoc
+  case class FromFile(file: String, line: String) extends SourceLoc
+
+  implicit def materialize: SourceInfo = macro Locators.injectSourceInfo
+
+  // Import this to suppress enclosure info details
+  object Suppress {
+    implicit val Implicitly = SourceInfo(None)
+  }
+}
+
+// Not for use by users directly!
+object Locators {
+  import scala.reflect.macros.blackbox.Context
+
+  def injectSourceInfo(c: Context): c.Tree = {
+    import c.universe._
+    val file = c.enclosingPosition.source.file.name.toString
+    val line = c.enclosingPosition.line.toString
+    val info = q"_root_.Chisel.SourceInfo.FromFile($file,$line)"
+    // sanitized SourceInfo(Some(SourceInfo.FromFile(file, line)))
+    q"_root_.Chisel.SourceInfo(_root_.scala.Some($info))"
+  }
+}

--- a/src/main/scala/Chisel/util/Arbiter.scala
+++ b/src/main/scala/Chisel/util/Arbiter.scala
@@ -62,7 +62,7 @@ class LockingRRArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[
     (0 until n).map(i => ctrl(i) && grantMask(i) || ctrl(i + n))
   }
 
-  override lazy val choice = Wire(init=UInt(n-1))
+  override lazy val choice = Wire(init=UInt(n-1))(SourceInfo(None))
   for (i <- n-2 to 0 by -1)
     when (io.in(i).valid) { choice := UInt(i) }
   for (i <- n-1 to 1 by -1)
@@ -73,7 +73,7 @@ class LockingArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T 
     extends LockingArbiterLike[T](gen, n, count, needsLock) {
   def grant: Seq[Bool] = ArbiterCtrl(io.in.map(_.valid))
 
-  override lazy val choice = Wire(init=UInt(n-1))
+  override lazy val choice = Wire(init=UInt(n-1))(SourceInfo(None))
   for (i <- n-2 to 0 by -1)
     when (io.in(i).valid) { choice := UInt(i) }
 }

--- a/src/main/scala/Chisel/util/Decoupled.scala
+++ b/src/main/scala/Chisel/util/Decoupled.scala
@@ -108,6 +108,10 @@ class Queue[T <: Data](gen: T, val entries: Int,
 {
   val io = new QueueIO(gen, entries)
 
+  private implicit val info = SourceInfo(Some(SourceInfo.FromFile(
+    "Decoupled.scala", "Queue"
+  )))
+
   val ram = Mem(entries, gen)
   val enq_ptr = Counter(entries)
   val deq_ptr = Counter(entries)

--- a/src/main/scala/Chisel/util/Valid.scala
+++ b/src/main/scala/Chisel/util/Valid.scala
@@ -32,7 +32,10 @@ object Valid {
   */
 object Pipe
 {
-  def apply[T <: Data](enqValid: Bool, enqBits: T, latency: Int): ValidIO[T] = {
+  def apply[T<:Data](
+    enqValid: Bool, enqBits: T, latency: Int)(implicit info: SourceInfo
+  ): ValidIO[T] =
+  {
     if (latency == 0) {
       val out = Wire(Valid(enqBits))
       out.valid <> enqValid
@@ -44,8 +47,10 @@ object Pipe
       apply(v, b, latency-1)
     }
   }
-  def apply[T <: Data](enqValid: Bool, enqBits: T): ValidIO[T] = apply(enqValid, enqBits, 1)
-  def apply[T <: Data](enq: ValidIO[T], latency: Int = 1): ValidIO[T] = apply(enq.valid, enq.bits, latency)
+  def apply[T<:Data](enqValid: Bool, enqBits: T)(implicit info: SourceInfo): ValidIO[T] =
+    apply(enqValid, enqBits, 1)
+  def apply[T<:Data](enq: ValidIO[T], latency: Int = 1)(implicit info: SourceInfo): ValidIO[T] =
+    apply(enq.valid, enq.bits, latency)
 }
 
 class Pipe[T <: Data](gen: T, latency: Int = 1) extends Module
@@ -55,5 +60,5 @@ class Pipe[T <: Data](gen: T, latency: Int = 1) extends Module
     val deq = Valid(gen)
   }
 
-  io.deq <> Pipe(io.enq, latency)
+  io.deq <> Pipe(io.enq, latency)(SourceInfo(None))
 }


### PR DESCRIPTION
First, this introduces the SourceInfo case class which contains an
Option[SourceInfo.SourceLoc]. The only current SourceInfo.SourceLoc is
FromFile(file: String, line: String).

A SourceInfo will be implicitly materialized via a macro if one is not
found earlier during implicit resolution. (An import or enclosing
implicit SourceInfo would be earlier.)

This change specifically adds implicit SourceInfo to Wire as a
demonstration. Wire was deemed 'safe' because you are extraordinarily
unlikely to 'apply' directly after a Wire. Notice how all the internal
uses of Wire had to have SourceInfo more directly supplied since
materialize could not be used due to macro resolution rules. (The
explicit SourceInfo suppression should be replaced by implicits in the
function calling wiring; however, some are liable to be followed by
'apply' and thus it is unsafe to do so without backwards compatibility
concerns)

PS: Ideally, the implicit materialize function would be 'hidden'
internally. This is partly why it is advised to import a subpackage of
Chisel and not just Chisel. Am contemplating introducing an intentional
implicit resolution conflict in the internal package object as a
stopgap.

Related to #147 