### PR TITLE
Have Bits.toBools return Seq, not Vec

### DIFF
--- a/chiselFrontend/src/main/scala/Chisel/Bits.scala
+++ b/chiselFrontend/src/main/scala/Chisel/Bits.scala
@@ -155,7 +155,7 @@ sealed abstract class Bits(dirArg: Direction, width: Width, override val litArg:
 
   /** Returns the contents of this wire as a [[Vec]] of [[Bool]]s.
     */
-  def toBools: Vec[Bool] = Vec.tabulate(this.getWidth)(i => this(i))
+  def toBools: Seq[Bool] = Seq.tabulate(this.getWidth)(i => this(i))
 
   /** Reinterpret cast to a SInt.
     *

--- a/chiselFrontend/src/main/scala/Chisel/Mem.scala
+++ b/chiselFrontend/src/main/scala/Chisel/Mem.scala
@@ -59,7 +59,7 @@ sealed abstract class MemBase[T <: Data](t: T, val length: Int) extends HasId wi
     *
     * @note this is only allowed if the memory's element data type is a Vec
     */
-  def write(idx: UInt, data: T, mask: Vec[Bool]) (implicit evidence: T <:< Vec[_]): Unit = {
+  def write(idx: UInt, data: T, mask: Seq[Bool]) (implicit evidence: T <:< Vec[_]): Unit = {
     val accessor = makePort(idx, MemPortDirection.WRITE).asInstanceOf[Vec[Data]]
     val dataVec = data.asInstanceOf[Vec[Data]]
     if (accessor.length != dataVec.length) {


### PR DESCRIPTION
The return value of Bits.toBools doesn't need to be dynamically indexed
(as you could have just dynamically indexed the Bits itself), so returning
a Seq instead of a Vec is mroe appropriate.

This breaks a circular dependence between Bits and Vec, which helps with
macros/frontend refactoring.