### PR TITLE
Move emit out of IR

### DIFF
--- a/chiselFrontend/src/main/scala/Chisel/internal/firrtl/Emitter.scala
+++ b/chiselFrontend/src/main/scala/Chisel/internal/firrtl/Emitter.scala
@@ -3,6 +3,10 @@
 package Chisel.internal.firrtl
 import Chisel._
 
+private[Chisel] object Emitter {
+  def emit(circuit: Circuit): String = new Emitter(circuit).toString
+}
+
 private class Emitter(circuit: Circuit) {
   override def toString: String = res.toString
 

--- a/chiselFrontend/src/main/scala/Chisel/internal/firrtl/IR.scala
+++ b/chiselFrontend/src/main/scala/Chisel/internal/firrtl/IR.scala
@@ -182,6 +182,4 @@ case class Printf(clk: Arg, formatIn: String, ids: Seq[Arg]) extends Command {
   }
 }
 
-case class Circuit(name: String, components: Seq[Component]) {
-  def emit: String = new Emitter(this).toString
-}
+case class Circuit(name: String, components: Seq[Component])

--- a/src/main/scala/Chisel/Driver.scala
+++ b/src/main/scala/Chisel/Driver.scala
@@ -110,12 +110,12 @@ object Driver extends BackendCompilationUtilities {
     */
   def elaborate[T <: Module](gen: () => T): Circuit = Builder.build(Module(gen()))
 
-  def emit[T <: Module](gen: () => T): String = elaborate(gen).emit
+  def emit[T <: Module](gen: () => T): String = Emitter.emit(elaborate(gen))
 
   def dumpFirrtl(ir: Circuit, optName: Option[File]): File = {
     val f = optName.getOrElse(new File(ir.name + ".fir"))
     val w = new FileWriter(f)
-    w.write(ir.emit)
+    w.write(Emitter.emit(ir))
     w.close()
     f
   }


### PR DESCRIPTION
Emit really has no business being in Circuit since the stuff in IR.scala is mostly just dumb structs without code. This moves the invocations of emit into Driver and allows access to Emitter throughout the entire Chisel package.

This is related to source locators, since it helps break another dependency and allows Emitter to be part of Chisel instead of Chisel Frontend.