### PR TITLE
Source locators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,17 +79,28 @@ lazy val chiselSettings = Seq (
   //  }
 )
 
-lazy val chiselFrontend = (project in file("chiselFrontend")).
+lazy val coreMacros = (project in file("coreMacros")).
   settings(commonSettings: _*).
   settings(
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value
   )
 
+lazy val chiselFrontend = (project in file("chiselFrontend")).
+  settings(commonSettings: _*).
+  settings(
+    libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value
+  ).
+  dependsOn(coreMacros)
+
 lazy val chisel = (project in file(".")).
   settings(commonSettings: _*).
   settings(chiselSettings: _*).
-  dependsOn(chiselFrontend).settings(
+  dependsOn(coreMacros).
+  dependsOn(chiselFrontend).
+  settings(
     // Include macro classes, resources, and sources main jar.
+    mappings in (Compile, packageBin) <++= mappings in (coreMacros, Compile, packageBin),
+    mappings in (Compile, packageSrc) <++= mappings in (coreMacros, Compile, packageSrc),
     mappings in (Compile, packageBin) <++= mappings in (chiselFrontend, Compile, packageBin),
     mappings in (Compile, packageSrc) <++= mappings in (chiselFrontend, Compile, packageSrc)
   )

--- a/chiselFrontend/src/main/scala/Chisel/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/Chisel/Aggregate.scala
@@ -4,10 +4,12 @@ package Chisel
 
 import scala.collection.immutable.ListMap
 import scala.collection.mutable.{ArrayBuffer, HashSet, LinkedHashMap}
+import scala.language.experimental.macros
 
 import internal._
 import internal.Builder.pushCommand
 import internal.firrtl._
+import internal.sourceinfo.{SourceInfo, DeprecatedSourceInfo, VecTransform, SourceInfoTransform}
 
 /** An abstract class for data types that solely consist of (are an aggregate
   * of) other Data objects.
@@ -36,14 +38,15 @@ object Vec {
     * element
     * @note output elements are connected from the input elements
     */
-  def apply[T <: Data](elts: Seq[T]): Vec[T] = {
+  def apply[T <: Data](elts: Seq[T]): Vec[T] = macro VecTransform.apply_elts
+
+  def do_apply[T <: Data](elts: Seq[T])(implicit sourceInfo: SourceInfo): Vec[T] = {
     // REVIEW TODO: this should be removed in favor of the apply(elts: T*)
     // varargs constructor, which is more in line with the style of the Scala
     // collection API. However, a deprecation phase isn't possible, since
     // changing apply(elt0, elts*) to apply(elts*) causes a function collision
     // with apply(Seq) after type erasure. Workarounds by either introducing a
     // DummyImplicit or additional type parameter will break some code.
-
     require(!elts.isEmpty)
     val width = elts.map(_.width).reduce(_ max _)
     val vec = Wire(new Vec(elts.head.cloneTypeWidth(width), elts.length))
@@ -60,7 +63,9 @@ object Vec {
     * element
     * @note output elements are connected from the input elements
     */
-  def apply[T <: Data](elt0: T, elts: T*): Vec[T] =
+  def apply[T <: Data](elt0: T, elts: T*): Vec[T] = macro VecTransform.apply_elt0
+
+  def do_apply[T <: Data](elt0: T, elts: T*)(implicit sourceInfo: SourceInfo): Vec[T] =
     apply(elt0 +: elts.toSeq)
 
   /** Creates a new [[Vec]] of length `n` composed of the results of the given
@@ -71,7 +76,9 @@ object Vec {
     * @param gen function that takes in an Int (the index) and returns a
     * [[Data]] that becomes the output element
     */
-  def tabulate[T <: Data](n: Int)(gen: (Int) => T): Vec[T] =
+  def tabulate[T <: Data](n: Int)(gen: (Int) => T): Vec[T] = macro VecTransform.tabulate
+
+  def do_tabulate[T <: Data](n: Int)(gen: (Int) => T)(implicit sourceInfo: SourceInfo): Vec[T] =
     apply((0 until n).map(i => gen(i)))
 
   /** Creates a new [[Vec]] of length `n` composed of the result of the given
@@ -82,7 +89,10 @@ object Vec {
     * @param gen function that generates the [[Data]] that becomes the output
     * element
     */
-  def fill[T <: Data](n: Int)(gen: => T): Vec[T] = apply(Seq.fill(n)(gen))
+  def fill[T <: Data](n: Int)(gen: => T): Vec[T] = macro VecTransform.fill
+
+  def do_fill[T <: Data](n: Int)(gen: => T)(implicit sourceInfo: SourceInfo): Vec[T] =
+    apply(Seq.fill(n)(gen))
 }
 
 /** A vector (array) of [[Data]] elements. Provides hardware versions of various
@@ -102,18 +112,18 @@ sealed class Vec[T <: Data] private (gen: => T, val length: Int)
 
   private val self = IndexedSeq.fill(length)(gen)
 
-  override def <> (that: Data): Unit = this := that
+  override def <> (that: Data)(implicit sourceInfo: SourceInfo): Unit = this := that
 
   /** Strong bulk connect, assigning elements in this Vec from elements in a Seq.
     *
     * @note the length of this Vec must match the length of the input Seq
     */
-  def <> (that: Seq[T]): Unit = this := that
+  def <> (that: Seq[T])(implicit sourceInfo: SourceInfo): Unit = this := that
 
   // TODO: eliminate once assign(Seq) isn't ambiguous with assign(Data) since Vec extends Seq and Data
-  def <> (that: Vec[T]): Unit = this := that.asInstanceOf[Data]
+  def <> (that: Vec[T])(implicit sourceInfo: SourceInfo): Unit = this := that.asInstanceOf[Data]
 
-  override def := (that: Data): Unit = that match {
+  override def := (that: Data)(implicit sourceInfo: SourceInfo): Unit = that match {
     case _: Vec[_] => this connect that
     case _ => this badConnect that
   }
@@ -122,14 +132,14 @@ sealed class Vec[T <: Data] private (gen: => T, val length: Int)
     *
     * @note the length of this Vec must match the length of the input Seq
     */
-  def := (that: Seq[T]): Unit = {
+  def := (that: Seq[T])(implicit sourceInfo: SourceInfo): Unit = {
     require(this.length == that.length)
     for ((a, b) <- this zip that)
       a := b
   }
 
   // TODO: eliminate once assign(Seq) isn't ambiguous with assign(Data) since Vec extends Seq and Data
-  def := (that: Vec[T]): Unit = this connect that
+  def := (that: Vec[T])(implicit sourceInfo: SourceInfo): Unit = this connect that
 
   /** Creates a dynamically indexed read or write accessor into the array.
     */
@@ -147,7 +157,7 @@ sealed class Vec[T <: Data] private (gen: => T, val length: Int)
   def read(idx: UInt): T = apply(idx)
 
   @deprecated("Use Vec.apply instead", "chisel3")
-  def write(idx: UInt, data: T): Unit = apply(idx) := data
+  def write(idx: UInt, data: T): Unit = apply(idx).:=(data)(DeprecatedSourceInfo)
 
   override def cloneType: this.type =
     Vec(length, gen).asInstanceOf[this.type]
@@ -175,20 +185,32 @@ trait VecLike[T <: Data] extends collection.IndexedSeq[T] {
 
   /** Outputs true if p outputs true for every element.
     */
-  def forall(p: T => Bool): Bool = (this map p).fold(Bool(true))(_ && _)
+  def forall(p: T => Bool): Bool = macro SourceInfoTransform.pArg
+
+  def do_forall(p: T => Bool)(implicit sourceInfo: SourceInfo): Bool =
+    (this map p).fold(Bool(true))(_ && _)
 
   /** Outputs true if p outputs true for at least one element.
     */
-  def exists(p: T => Bool): Bool = (this map p).fold(Bool(false))(_ || _)
+  def exists(p: T => Bool): Bool = macro SourceInfoTransform.pArg
+
+  def do_exists(p: T => Bool)(implicit sourceInfo: SourceInfo): Bool =
+    (this map p).fold(Bool(false))(_ || _)
 
   /** Outputs true if the vector contains at least one element equal to x (using
     * the === operator).
     */
-  def contains(x: T)(implicit evidence: T <:< UInt): Bool = this.exists(_ === x)
+  def contains(x: T)(implicit ev: T <:< UInt): Bool = macro VecTransform.contains
+
+  def do_contains(x: T)(implicit sourceInfo: SourceInfo, ev: T <:< UInt): Bool =
+    this.exists(_ === x)
 
   /** Outputs the number of elements for which p is true.
     */
-  def count(p: T => Bool): UInt = SeqUtils.count(this map p)
+  def count(p: T => Bool): UInt = macro SourceInfoTransform.pArg
+
+  def do_count(p: T => Bool)(implicit sourceInfo: SourceInfo): UInt =
+    SeqUtils.count(this map p)
 
   /** Helper function that appends an index (literal value) to each element,
     * useful for hardware generators which output an index.
@@ -197,11 +219,17 @@ trait VecLike[T <: Data] extends collection.IndexedSeq[T] {
 
   /** Outputs the index of the first element for which p outputs true.
     */
-  def indexWhere(p: T => Bool): UInt = SeqUtils.priorityMux(indexWhereHelper(p))
+  def indexWhere(p: T => Bool): UInt = macro SourceInfoTransform.pArg
+
+  def do_indexWhere(p: T => Bool)(implicit sourceInfo: SourceInfo): UInt =
+    SeqUtils.priorityMux(indexWhereHelper(p))
 
   /** Outputs the index of the last element for which p outputs true.
     */
-  def lastIndexWhere(p: T => Bool): UInt = SeqUtils.priorityMux(indexWhereHelper(p).reverse)
+  def lastIndexWhere(p: T => Bool): UInt = macro SourceInfoTransform.pArg
+
+  def do_lastIndexWhere(p: T => Bool)(implicit sourceInfo: SourceInfo): UInt =
+    SeqUtils.priorityMux(indexWhereHelper(p).reverse)
 
   /** Outputs the index of the element for which p outputs true, assuming that
     * the there is exactly one such element.
@@ -213,7 +241,10 @@ trait VecLike[T <: Data] extends collection.IndexedSeq[T] {
     * true is NOT checked (useful in cases where the condition doesn't always
     * hold, but the results are not used in those cases)
     */
-  def onlyIndexWhere(p: T => Bool): UInt = SeqUtils.oneHotMux(indexWhereHelper(p))
+  def onlyIndexWhere(p: T => Bool): UInt = macro SourceInfoTransform.pArg
+
+  def do_onlyIndexWhere(p: T => Bool)(implicit sourceInfo: SourceInfo): UInt =
+    SeqUtils.oneHotMux(indexWhereHelper(p))
 }
 
 /** Base class for data types defined as a bundle of other data types.
@@ -237,13 +268,13 @@ class Bundle extends Aggregate(NO_DIR) {
     * mySubModule.io <> io
     * }}}
     */
-  override def <> (that: Data): Unit = that match {
+  override def <> (that: Data)(implicit sourceInfo: SourceInfo): Unit = that match {
     case _: Bundle => this bulkConnect that
     case _ => this badConnect that
   }
 
   // TODO: replace with better defined FIRRTL strong-connect operator
-  override def := (that: Data): Unit = this <> that
+  override def := (that: Data)(implicit sourceInfo: SourceInfo): Unit = this <> that
 
   lazy val elements: ListMap[String, Data] = ListMap(namedElts:_*)
 

--- a/chiselFrontend/src/main/scala/Chisel/BitPat.scala
+++ b/chiselFrontend/src/main/scala/Chisel/BitPat.scala
@@ -2,6 +2,10 @@
 
 package Chisel
 
+import scala.language.experimental.macros
+
+import Chisel.internal.sourceinfo.{SourceInfo, SourceInfoTransform}
+
 object BitPat {
   /** Parses a bit pattern string into (bits, mask, width).
     *
@@ -74,7 +78,11 @@ object BitPat {
   */
 sealed class BitPat(val value: BigInt, val mask: BigInt, width: Int) {
   def getWidth: Int = width
-  def === (other: UInt): Bool = UInt(value) === (other & UInt(mask))
-  def =/= (other: UInt): Bool = !(this === other)
-  def != (other: UInt): Bool = this =/= other
+  def === (that: UInt): Bool = macro SourceInfoTransform.thatArg
+  def =/= (that: UInt): Bool = macro SourceInfoTransform.thatArg
+  def != (that: UInt): Bool = macro SourceInfoTransform.thatArg
+
+  def do_=== (that: UInt)(implicit sourceInfo: SourceInfo): Bool = UInt(value) === (that & UInt(mask))
+  def do_=/= (that: UInt)(implicit sourceInfo: SourceInfo): Bool = !(this === that)
+  def do_!= (that: UInt)(implicit sourceInfo: SourceInfo): Bool = this =/= that
 }

--- a/chiselFrontend/src/main/scala/Chisel/BlackBox.scala
+++ b/chiselFrontend/src/main/scala/Chisel/BlackBox.scala
@@ -4,6 +4,7 @@ package Chisel
 
 import internal.Builder.pushCommand
 import internal.firrtl.{ModuleIO, DefInvalid}
+import internal.sourceinfo.SourceInfo
 
 /** Defines a black box, which is a module that can be referenced from within
   * Chisel, but is not defined in the emitted Verilog. Useful for connecting
@@ -39,10 +40,10 @@ abstract class BlackBox extends Module {
 
   // Don't setup clock, reset
   // Cann't invalide io in one bunch, must invalidate each part separately
-  override private[Chisel] def setupInParent(): this.type = _parent match {
+  override private[Chisel] def setupInParent(implicit sourceInfo: SourceInfo): this.type = _parent match {
     case Some(p) => {
       // Just init instance inputs
-      for((_,port) <- ports) pushCommand(DefInvalid(port.ref))
+      for((_,port) <- ports) pushCommand(DefInvalid(sourceInfo, port.ref))
       this
     }
     case None => this

--- a/chiselFrontend/src/main/scala/Chisel/Printf.scala
+++ b/chiselFrontend/src/main/scala/Chisel/Printf.scala
@@ -1,0 +1,36 @@
+// See LICENSE for license details.
+
+package Chisel
+
+import scala.language.experimental.macros
+
+import internal._
+import internal.Builder.pushCommand
+import internal.firrtl._
+import internal.sourceinfo.SourceInfo
+
+object printf { // scalastyle:ignore object.name
+  /** Prints a message in simulation.
+    *
+    * Does not fire when in reset (defined as the encapsulating Module's
+    * reset). If your definition of reset is not the encapsulating Module's
+    * reset, you will need to gate this externally.
+    *
+    * May be called outside of a Module (like defined in a function), so
+    * functions using printf make the standard Module assumptions (single clock
+    * and single reset).
+    *
+    * @param fmt printf format string
+    * @param data format string varargs containing data to print
+    */
+  def apply(fmt: String, data: Bits*)(implicit sourceInfo: SourceInfo) {
+    when (!(Builder.dynamicContext.currentModule.get.reset)) {
+      printfWithoutReset(fmt, data:_*)
+    }
+  }
+
+  private[Chisel] def printfWithoutReset(fmt: String, data: Bits*)(implicit sourceInfo: SourceInfo) {
+    val clock = Builder.dynamicContext.currentModule.get.clock
+    pushCommand(Printf(sourceInfo, Node(clock), fmt, data.map((d: Bits) => d.ref)))
+  }
+}

--- a/chiselFrontend/src/main/scala/Chisel/SeqUtils.scala
+++ b/chiselFrontend/src/main/scala/Chisel/SeqUtils.scala
@@ -2,9 +2,15 @@
 
 package Chisel
 
+import scala.language.experimental.macros
+
+import internal.sourceinfo.{SourceInfo, SourceInfoTransform}
+
 private[Chisel] object SeqUtils {
   /** Equivalent to Cat(r(n-1), ..., r(0)) */
-  def asUInt[T <: Bits](in: Seq[T]): UInt = {
+  def asUInt[T <: Bits](in: Seq[T]): UInt = macro SourceInfoTransform.inArg
+
+  def do_asUInt[T <: Bits](in: Seq[T])(implicit sourceInfo: SourceInfo): UInt = {
     if (in.tail.isEmpty) {
       in.head.asUInt
     } else {
@@ -15,7 +21,9 @@ private[Chisel] object SeqUtils {
   }
 
   /** Counts the number of true Bools in a Seq */
-  def count(in: Seq[Bool]): UInt = {
+  def count(in: Seq[Bool]): UInt = macro SourceInfoTransform.inArg
+
+  def do_count(in: Seq[Bool])(implicit sourceInfo: SourceInfo): UInt = {
     if (in.size == 0) {
       UInt(0)
     } else if (in.size == 1) {
@@ -26,7 +34,9 @@ private[Chisel] object SeqUtils {
   }
 
   /** Returns data value corresponding to first true predicate */
-  def priorityMux[T <: Bits](in: Seq[(Bool, T)]): T = {
+  def priorityMux[T <: Bits](in: Seq[(Bool, T)]): T = macro SourceInfoTransform.inArg
+
+  def do_priorityMux[T <: Bits](in: Seq[(Bool, T)])(implicit sourceInfo: SourceInfo): T = {
     if (in.size == 1) {
       in.head._2
     } else {
@@ -35,7 +45,9 @@ private[Chisel] object SeqUtils {
   }
 
   /** Returns data value corresponding to lone true predicate */
-  def oneHotMux[T <: Data](in: Iterable[(Bool, T)]): T = {
+  def oneHotMux[T <: Data](in: Iterable[(Bool, T)]): T = macro SourceInfoTransform.inArg
+
+  def do_oneHotMux[T <: Data](in: Iterable[(Bool, T)])(implicit sourceInfo: SourceInfo): T = {
     if (in.tail.isEmpty) {
       in.head._2
     } else {

--- a/chiselFrontend/src/main/scala/Chisel/internal/SourceInfo.scala
+++ b/chiselFrontend/src/main/scala/Chisel/internal/SourceInfo.scala
@@ -1,0 +1,51 @@
+// See LICENSE for license details.
+
+// This file contains macros for adding source locators at the point of invocation.
+//
+// This is not part of coreMacros to disallow this macro from being implicitly invoked in Chisel
+// frontend (and generating source locators in Chisel core), which is almost certainly a bug.
+//
+// Note: While these functions and definitions are not private (macros can't be
+// private), these are NOT meant to be part of the public API (yet) and no
+// forward compatibility guarantees are made.
+// A future revision may stabilize the source locator API to allow library
+// writers to append source locator information at the point of a library
+// function invocation.
+
+package Chisel.internal.sourceinfo
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+/** Abstract base class for generalized source information.
+  */
+sealed trait SourceInfo
+
+sealed trait NoSourceInfo extends SourceInfo
+
+/** For when source info can't be generated because of a technical limitation, like for Reg because
+  * Scala macros don't support named or default arguments.
+  */
+case object UnlocatableSourceInfo extends NoSourceInfo
+
+/** For when source info isn't generated because the function is deprecated and we're lazy.
+  */
+case object DeprecatedSourceInfo extends NoSourceInfo
+
+/** For FIRRTL lines from a Scala source line.
+  */
+case class SourceLine(filename: String, line: Int, col: Int) extends SourceInfo
+
+/** Provides a macro that returns the source information at the invocation point.
+  */
+object SourceInfoMacro {
+  def generate_source_info(c: Context): c.Tree = {
+    import c.universe._
+    val p = c.enclosingPosition
+    q"_root_.Chisel.internal.sourceinfo.SourceLine(${p.source.file.name}, ${p.line}, ${p.column})"
+  }
+}
+
+object SourceInfo {
+  implicit def materialize: SourceInfo = macro SourceInfoMacro.generate_source_info
+}

--- a/chiselFrontend/src/main/scala/Chisel/internal/firrtl/IR.scala
+++ b/chiselFrontend/src/main/scala/Chisel/internal/firrtl/IR.scala
@@ -3,6 +3,7 @@
 package Chisel.internal.firrtl
 import Chisel._
 import Chisel.internal._
+import Chisel.internal.sourceinfo.{SourceInfo, NoSourceInfo}
 
 case class PrimOp(val name: String) {
   override def toString: String = name
@@ -142,29 +143,31 @@ object MemPortDirection {
   object INFER extends MemPortDirection("infer")
 }
 
-abstract class Command
+abstract class Command {
+  def sourceInfo: SourceInfo
+}
 abstract class Definition extends Command {
   def id: HasId
   def name: String = id.getRef.name
 }
-case class DefPrim[T <: Data](id: T, op: PrimOp, args: Arg*) extends Definition
-case class DefInvalid(arg: Arg) extends Command
-case class DefWire(id: Data) extends Definition
-case class DefReg(id: Data, clock: Arg) extends Definition
-case class DefRegInit(id: Data, clock: Arg, reset: Arg, init: Arg) extends Definition
-case class DefMemory(id: HasId, t: Data, size: Int) extends Definition
-case class DefSeqMemory(id: HasId, t: Data, size: Int) extends Definition
-case class DefMemPort[T <: Data](id: T, source: Node, dir: MemPortDirection, index: Arg, clock: Arg) extends Definition
-case class DefInstance(id: Module, ports: Seq[Port]) extends Definition
-case class WhenBegin(pred: Arg) extends Command
-case class WhenEnd() extends Command
-case class Connect(loc: Node, exp: Arg) extends Command
-case class BulkConnect(loc1: Node, loc2: Node) extends Command
-case class ConnectInit(loc: Node, exp: Arg) extends Command
-case class Stop(clk: Arg, ret: Int) extends Command
+case class DefPrim[T <: Data](sourceInfo: SourceInfo, id: T, op: PrimOp, args: Arg*) extends Definition
+case class DefInvalid(sourceInfo: SourceInfo, arg: Arg) extends Command
+case class DefWire(sourceInfo: SourceInfo, id: Data) extends Definition
+case class DefReg(sourceInfo: SourceInfo, id: Data, clock: Arg) extends Definition
+case class DefRegInit(sourceInfo: SourceInfo, id: Data, clock: Arg, reset: Arg, init: Arg) extends Definition
+case class DefMemory(sourceInfo: SourceInfo, id: HasId, t: Data, size: Int) extends Definition
+case class DefSeqMemory(sourceInfo: SourceInfo, id: HasId, t: Data, size: Int) extends Definition
+case class DefMemPort[T <: Data](sourceInfo: SourceInfo, id: T, source: Node, dir: MemPortDirection, index: Arg, clock: Arg) extends Definition
+case class DefInstance(sourceInfo: SourceInfo, id: Module, ports: Seq[Port]) extends Definition
+case class WhenBegin(sourceInfo: SourceInfo, pred: Arg) extends Command
+case class WhenEnd(sourceInfo: SourceInfo) extends Command
+case class Connect(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
+case class BulkConnect(sourceInfo: SourceInfo, loc1: Node, loc2: Node) extends Command
+case class ConnectInit(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
+case class Stop(sourceInfo: SourceInfo, clk: Arg, ret: Int) extends Command
 case class Component(id: Module, name: String, ports: Seq[Port], commands: Seq[Command]) extends Arg
 case class Port(id: Data, dir: Direction)
-case class Printf(clk: Arg, formatIn: String, ids: Seq[Arg]) extends Command {
+case class Printf(sourceInfo: SourceInfo, clk: Arg, formatIn: String, ids: Seq[Arg]) extends Command {
   require(formatIn.forall(c => c.toInt > 0 && c.toInt < 128), "format strings must comprise non-null ASCII values")
   def format: String = {
     def escaped(x: Char) = {

--- a/coreMacros/src/main/scala/Chisel/internal/sourceinfo/SourceInfoTransform.scala
+++ b/coreMacros/src/main/scala/Chisel/internal/sourceinfo/SourceInfoTransform.scala
@@ -1,0 +1,156 @@
+// See LICENSE for license details.
+
+// This file transform macro definitions to explicitly add implicit source info to Chisel method
+// calls.
+
+package Chisel.internal.sourceinfo
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+import scala.reflect.macros.whitebox
+
+
+/** Transforms a function call so that it can both provide implicit-style source information and
+  * have a chained apply call. Without macros, only one is possible, since having a implicit
+  * argument in the definition will cause the compiler to interpret a chained apply as an
+  * explicit implicit argument and give type errors.
+  *
+  * Instead of an implicit argument, the public-facing function no longer takes a SourceInfo at all.
+  * The macro transforms the public-facing function into a call to an internal function that takes
+  * an explicit SourceInfo by inserting an implicitly[SourceInfo] as the explicit argument.
+  */
+trait SourceInfoTransformMacro {
+  val c: Context
+  import c.universe._
+  def thisObj = c.prefix.tree
+  def implicitSourceInfo = q"implicitly[_root_.Chisel.internal.sourceinfo.SourceInfo]"
+}
+
+class WireTransform(val c: Context) extends SourceInfoTransformMacro {
+  import c.universe._
+  def apply[T: c.WeakTypeTag](t: c.Tree): c.Tree = {
+    val tpe = weakTypeOf[T]
+    q"$thisObj.do_apply($t, null.asInstanceOf[$tpe])($implicitSourceInfo)"
+  }
+}
+
+class UIntTransform(val c: Context) extends SourceInfoTransformMacro {
+  import c.universe._
+  def bitset(off: c.Tree, dat: c.Tree): c.Tree = {
+    q"$thisObj.do_bitSet($off, $dat)($implicitSourceInfo)"
+  }
+}
+
+// Module instantiation transform
+class InstTransform(val c: Context) extends SourceInfoTransformMacro {
+  import c.universe._
+  def apply[T: c.WeakTypeTag](bc: c.Tree): c.Tree = {
+    q"$thisObj.do_apply($bc)($implicitSourceInfo)"
+  }
+}
+
+class MemTransform(val c: Context) extends SourceInfoTransformMacro {
+  import c.universe._
+  def apply[T: c.WeakTypeTag](size: c.Tree, t: c.Tree): c.Tree = {
+    q"$thisObj.do_apply($size, $t)($implicitSourceInfo)"
+  }
+}
+
+class RegTransform(val c: Context) extends SourceInfoTransformMacro {
+  import c.universe._
+  def apply[T: c.WeakTypeTag](t: c.Tree): c.Tree = {
+    val tpe = weakTypeOf[T]
+    q"$thisObj.do_apply($t, null.asInstanceOf[$tpe], null.asInstanceOf[$tpe])($implicitSourceInfo)"
+  }
+}
+
+class MuxTransform(val c: Context) extends SourceInfoTransformMacro {
+  import c.universe._
+  def apply[T: c.WeakTypeTag](cond: c.Tree, con: c.Tree, alt: c.Tree): c.Tree = {
+    val tpe = weakTypeOf[T]
+    q"$thisObj.do_apply[$tpe]($cond, $con, $alt)($implicitSourceInfo)"
+  }
+}
+
+class VecTransform(val c: Context) extends SourceInfoTransformMacro {
+  import c.universe._
+  def apply_elts(elts: c.Tree): c.Tree = {
+    q"$thisObj.do_apply($elts)($implicitSourceInfo)"
+  }
+  def apply_elt0(elt0: c.Tree, elts: c.Tree*): c.Tree = {
+    q"$thisObj.do_apply($elt0, ..$elts)($implicitSourceInfo)"
+  }
+  def tabulate(n: c.Tree)(gen: c.Tree): c.Tree = {
+    q"$thisObj.do_tabulate($n)($gen)($implicitSourceInfo)"
+  }
+  def fill(n: c.Tree)(gen: c.Tree): c.Tree = {
+    q"$thisObj.do_fill($n)($gen)($implicitSourceInfo)"
+  }
+  def contains(x: c.Tree)(ev: c.Tree): c.Tree = {
+    q"$thisObj.do_contains($x)($implicitSourceInfo, $ev)"
+  }
+}
+
+/** "Automatic" source information transform / insertion macros, which generate the function name
+  * based on the macro invocation (instead of explicitly writing out every transform).
+  */
+abstract class AutoSourceTransform extends SourceInfoTransformMacro {
+  import c.universe._
+  /** Returns the TermName of the transformed function, which is the applied function name with do_
+    * prepended.
+    */
+  def doFuncTerm = {
+    val funcName = c.macroApplication match {
+      case q"$_.$funcName[..$_](...$_)" => funcName
+      case _ => throw new Exception(s"Chisel Internal Error: Could not resolve function name from macro application: ${showCode(c.macroApplication)}")
+    }
+    TermName("do_" + funcName)
+  }
+}
+
+class SourceInfoTransform(val c: Context) extends AutoSourceTransform {
+  import c.universe._
+
+  def noArg(): c.Tree = {
+    q"$thisObj.$doFuncTerm($implicitSourceInfo)"
+  }
+
+  def thatArg(that: c.Tree): c.Tree = {
+    q"$thisObj.$doFuncTerm($that)($implicitSourceInfo)"
+  }
+
+  def nArg(n: c.Tree): c.Tree = {
+    q"$thisObj.$doFuncTerm($n)($implicitSourceInfo)"
+  }
+
+  def pArg(p: c.Tree): c.Tree = {
+    q"$thisObj.$doFuncTerm($p)($implicitSourceInfo)"
+  }
+
+  def inArg(in: c.Tree): c.Tree = {
+    q"$thisObj.$doFuncTerm($in)($implicitSourceInfo)"
+  }
+
+  def xArg(x: c.Tree): c.Tree = {
+    q"$thisObj.$doFuncTerm($x)($implicitSourceInfo)"
+  }
+
+  def xyArg(x: c.Tree, y: c.Tree): c.Tree = {
+    q"$thisObj.$doFuncTerm($x, $y)($implicitSourceInfo)"
+  }
+}
+
+/** Special whitebox version of the blackbox SourceInfoTransform, used when fun things need to happen to satisfy the
+  * type system while preventing the use of macro overrides.
+  */
+class SourceInfoWhiteboxTransform(val c: whitebox.Context) extends AutoSourceTransform {
+  import c.universe._
+
+  def noArg(): c.Tree = {
+    q"$thisObj.$doFuncTerm($implicitSourceInfo)"
+  }
+
+  def thatArg(that: c.Tree): c.Tree = {
+    q"$thisObj.$doFuncTerm($that)($implicitSourceInfo)"
+  }
+}

--- a/src/main/scala/Chisel/testers/BasicTester.scala
+++ b/src/main/scala/Chisel/testers/BasicTester.scala
@@ -3,9 +3,12 @@
 package Chisel.testers
 import Chisel._
 
+import scala.language.experimental.macros
+
 import internal._
 import internal.Builder.pushCommand
 import internal.firrtl._
+import internal.sourceinfo.SourceInfo
 
 class BasicTester extends Module {
   // The testbench has no IOs, rather it should communicate using printf, assert, and stop.
@@ -19,9 +22,10 @@ class BasicTester extends Module {
     * reset). If your definition of reset is not the encapsulating Module's
     * reset, you will need to gate this externally.
     */
-  def stop() {
+  def stop()(implicit sourceInfo: SourceInfo) {
+    // TODO: rewrite this using library-style SourceInfo passing.
     when (!reset) {
-      pushCommand(Stop(Node(clock), 0))
+      pushCommand(Stop(sourceInfo, Node(clock), 0))
     }
   }
 


### PR DESCRIPTION
This basically adds the SourceInfo trait and several concrete classes for when source information isn't available and a concrete class for source information from a Scala source line.

Source information is also added to the FIRRTL IR nodes and emitter as an explicit parameter. Source information is propagated through the Chisel frontend and internals as an implicit parameter. For methods that don't return Unit (aka nothing), a macro transform explicitly adds the SourceInfo parameter as implicitly[SourceInfo] so apply() calls can be chained after. The transformed versions of methods are of the same name, except with `do_` prepended. One of the macros (`SourceInfoTransform`) automatically detects the function name, which eliminates a lot of boilerplate.

The package split is up for debate. There is two packages:
coreMacros defines the transforms (that add explicit implicits: `implicitly[SourceInfo]`) and nothing else. This allows the macros to be used and invoked at the next level, which prevents a lot of ugly `do_*` calls everywhere. Turns out you just need the macro transform definitions, not the functions that are defined as macros, in a different compilation unit.
chiselFrontend defines the core data types. ~~There's no real reason this needs to be separate from the rest of Chisel (other than the assert macros), but I think there's a certain elegance for splitting core data types from helpers (Driver and friends) and utils.~~ chiselFrontend is split out from the rest of utils as a layer of safety, since the `SourceInfo.materialize` macro is defined in chiselFrontend, this prevents the system from generating source locators in Chisel core, which is almost certainly a bug.

Mems a work in progress, and is dependent on #189. Will be future work, probably near future work.

Defining how library writers would have source locators for entry points into their libraries is future work.

~~Only tested with Chisel unit tests. Someone should test with a more complex design, like rocket chip. **Requires a FIRRTL compiler change to support the source info annotations. This will not yet work.** However, you can test correctness without source locators passed through to FIRRTL by eliminating the part in Emitter.scala where the locators are actually generated.~~

ucb-bar/firrtl#166 is in, so this should work now!

Implementation for #147 
Partially based on implementation sketch in #158