### PR TITLE
Update BackendCompilationUtilities.verilogToCpp to specify top-module

### DIFF
--- a/src/main/scala/Chisel/Driver.scala
+++ b/src/main/scala/Chisel/Driver.scala
@@ -46,17 +46,15 @@ trait BackendCompilationUtilities {
     * The Verilator prefix will be V$dutFile, and running this will generate
     * C++ sources and headers as well as a makefile to compile them.
     *
-    * Verilator will automatically locate the top-level module as the one among
-    * all the files which are not included elsewhere. If multiple ones exist,
-    * the compilation will fail.
-    *
     * @param dutFile name of the DUT .v without the .v extension
+    * @param name of the top-level module in the design
     * @param dir output directory
     * @param vSources list of additional Verilog sources to compile
     * @param cppHarness C++ testharness to compile/link against
     */
   def verilogToCpp(
       dutFile: String,
+      topModule: String,
       dir: File,
       vSources: Seq[File],
       cppHarness: File
@@ -70,8 +68,9 @@ trait BackendCompilationUtilities {
         "-Wno-STMTDLY",
         "--trace",
         "-O2",
+        "--top-module", topModule,
         "+define+TOP_TYPE=V" + dutFile,
-        s"+define+PRINTF_COND=!$dutFile.reset",
+        s"+define+PRINTF_COND=!$topModule.reset",
         "-CFLAGS",
         s"""-Wno-undefined-bool-conversion -O2 -DTOP_TYPE=V$dutFile -include V$dutFile.h""",
         "-Mdir", dir.toString,

--- a/src/main/scala/Chisel/testers/TesterDriver.scala
+++ b/src/main/scala/Chisel/testers/TesterDriver.scala
@@ -47,7 +47,7 @@ object TesterDriver extends BackendCompilationUtilities {
 
     // Use sys.Process to invoke a bunch of backend stuff, then run the resulting exe
     if ((firrtlToVerilog(target, path) #&&
-        verilogToCpp(target, path, additionalVFiles, cppHarness) #&&
+        verilogToCpp(target, target, path, additionalVFiles, cppHarness) #&&
         cppToExe(target, path)).! == 0) {
       executeExpectingSuccess(target, path)
     } else {

--- a/src/test/scala/chiselTests/Harness.scala
+++ b/src/test/scala/chiselTests/Harness.scala
@@ -55,7 +55,7 @@ int main(int argc, char **argv, char **env) {
     val cppHarness = makeCppHarness(fname)
 
     make(fname)
-    verilogToCpp(target, path, Seq(), cppHarness).!
+    verilogToCpp(target, target, path, Seq(), cppHarness).!
     cppToExe(target, path).!
     (path, target)
   }


### PR DESCRIPTION
This prevents Verilator from erroring when it cannot determine the top-module.
It also changes the PRINTF_COND guard to correctly use the top-level reset
instead of just the top of the Chisel-generated code.

This is useful because FIRRTL has so far duplicated all of the functionality in BackendCompilationUtilities, but now that we have releases, I'd like to just include chisel3 as a test dependency for FIRRTL. This specification of top-module is a problem in FIRRTL when modules are inlined (but consequently not deleted, perhaps this should be done instead?), so without this fix, FIRRTL still has to duplicate the functionality of verilogToCpp because it needs the ability to specify top-module.

Also, using $dutFile.reset is a bug if dutFile doesn't have the top-level module.