### PR TITLE
Publishcfe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,6 @@ lazy val chisel = (project in file(".")).
   )
 
 // This is ugly. There must be a better way.
-publish <<= (publish) dependsOn (publish in chiselFrontend)
+publish <<= (publish) dependsOn (publish in coreMacros, publish in chiselFrontend)
 
-publishLocal <<= (publishLocal) dependsOn (publishLocal in chiselFrontend)
-
+publishLocal <<= (publishLocal) dependsOn (publishLocal in coreMacros, publishLocal in chiselFrontend)

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ lazy val commonSettings = Seq (
 lazy val chiselSettings = Seq (
   organization := "edu.berkeley.cs",
   version := "3.0",
+  name := "Chisel3",
   git.remoteRepo := "git@github.com:ucb-bar/chisel3.git",
 
   publishMavenStyle := true,

--- a/build.sbt
+++ b/build.sbt
@@ -93,3 +93,11 @@ lazy val chisel = (project in file(".")).
     mappings in (Compile, packageBin) <++= mappings in (chiselFrontend, Compile, packageBin),
     mappings in (Compile, packageSrc) <++= mappings in (chiselFrontend, Compile, packageSrc)
   )
+
+// This is ugly. There must be a better way.
+publish <<= (publish) dependsOn (publish in chiselFrontend)
+
+publishLocal <<= (publishLocal) dependsOn (publishLocal in chiselFrontend)
+
+publishSigned <<= (publishSigned) dependsOn (publishSigned in chiselFrontend)
+

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,6 @@ lazy val commonSettings = Seq (
 lazy val chiselSettings = Seq (
   organization := "edu.berkeley.cs",
   version := "3.0",
-  name := "Chisel3",
   git.remoteRepo := "git@github.com:ucb-bar/chisel3.git",
 
   publishMavenStyle := true,

--- a/build.sbt
+++ b/build.sbt
@@ -99,5 +99,3 @@ publish <<= (publish) dependsOn (publish in chiselFrontend)
 
 publishLocal <<= (publishLocal) dependsOn (publishLocal in chiselFrontend)
 
-publishSigned <<= (publishSigned) dependsOn (publishSigned in chiselFrontend)
-


### PR DESCRIPTION
It initially looked like the manipulation of mappings in build.sbt was sufficient to include the chiselFrontend (and now coreMacros) code in the chisel3 jar. This appears not to be the case. Until such time as we're able to include the sub-project artifacts in the main jar, we need to explicitly publish the sub-project jars.