### PR TITLE
Add Assert Data

### DIFF
--- a/src/main/scala/Chisel/util/TransitName.scala
+++ b/src/main/scala/Chisel/util/TransitName.scala
@@ -2,14 +2,16 @@ package Chisel
 
 import internal.HasId
 
+/**
+ * The purpose of TransitName is to allow a library to 'move' a name
+ * call to a more appropriate place.
+ * For example, a library factory function may create a module and return
+ * the io. The only user-exposed field is that given IO, which can't use
+ * any name supplied by the user. This can add a hook so that the supplied
+ * name then names the Module.
+ * See Queue companion object for working example
+ */
 object TransitName {
-  // The purpose of this is to allow a library to 'move' a name call to a more
-  // appropriate place.
-  // For example, a library factory function may create a module and return
-  // the io. The only user-exposed field is that given IO, which can't use
-  // any name supplied by the user. This can add a hook so that the supplied
-  // name then names the Module.
-  // See Queue companion object for working example
   def apply[T<:HasId](from: T, to: HasId): T = {
     from.addPostnameHook((given_name: String) => {to.suggestName(given_name)})
     from


### PR DESCRIPTION
Allow user to insert Bits into their assert message.
printf allows the use of format specifiers for inserting data from Bits
at hardware simulation time into the message. This just extends assert
to allow the same.