### PR TITLE
Fixup to Chisel connections, literal creation, direction, etc.

### DIFF
--- a/src/main/scala/Chisel/BitPat.scala
+++ b/src/main/scala/Chisel/BitPat.scala
@@ -52,7 +52,7 @@ object BitPat {
     */
   implicit def bitPatToUInt(x: BitPat): UInt = {
     require(x.mask == (BigInt(1) << x.getWidth) - 1)
-    UInt(x.value, x.getWidth)
+    x.value.asUInt(x.getWidth)
   }
 
   /** Allows UInts to be used where a BitPat is expected, useful for when an
@@ -70,11 +70,11 @@ object BitPat {
 // TODO: Break out of Core? (this doesn't involve FIRRTL generation)
 /** Bit patterns are literals with masks, used to represent values with don't
   * cares. Equality comparisons will ignore don't care bits (for example,
-  * BitPat(0b10?1) === UInt(0b1001) and UInt(0b1011)).
+  * BitPat(0b10?1) === 0b1001.asUInt and 0b1011.asUInt.
   */
 sealed class BitPat(val value: BigInt, val mask: BigInt, width: Int) {
   def getWidth: Int = width
-  def === (other: UInt): Bool = UInt(value) === (other & UInt(mask))
+  def === (other: UInt): Bool = value.asUInt === (other & mask.asUInt)
   def =/= (other: UInt): Bool = !(this === other)
   def != (other: UInt): Bool = this =/= other
 }

--- a/src/main/scala/Chisel/CoreUtil.scala
+++ b/src/main/scala/Chisel/CoreUtil.scala
@@ -49,10 +49,10 @@ object assert { // scalastyle:ignore object.name
     q"$apply_impl_do($cond, $line, $message)"
   }
 
-  def apply_impl_do(cond: Bool, line: String, message: String, data: Bits*): Unit = {
-    when (!(cond || Builder.dynamicContext.currentModule.get.reset)) {
-      printf.printfWithoutReset(s"Assertion failed at $line: $message\n", data:_*)
-      pushCommand(Stop(Node(Builder.dynamicContext.currentModule.get.clock), 1))
+ def apply_impl_do(cond: Bool, line: String, message: String, data: Bits*) {
+    when (!(cond || Builder.forcedModule.reset)) {
+        printf.printfWithoutReset(s"Assertion failed at $line: $message\n", data:_*)
+        pushCommand(Stop(Node(Builder.forcedModule.clock), 1))
     }
   }
 
@@ -85,13 +85,13 @@ object printf { // scalastyle:ignore object.name
     * @param data format string varargs containing data to print
     */
   def apply(fmt: String, data: Bits*) {
-    when (!Builder.dynamicContext.currentModule.get.reset) {
+    when (!Builder.forcedModule.reset) {
       printfWithoutReset(fmt, data:_*)
     }
   }
 
   private[Chisel] def printfWithoutReset(fmt: String, data: Bits*) {
-    val clock = Builder.dynamicContext.currentModule.get.clock
+    val clock = Builder.forcedModule.clock
     pushCommand(Printf(Node(clock), fmt, data.map((d: Bits) => d.ref)))
   }
 }

--- a/src/main/scala/Chisel/Data.scala
+++ b/src/main/scala/Chisel/Data.scala
@@ -10,18 +10,69 @@ sealed abstract class Direction(name: String) {
   override def toString: String = name
   def flip: Direction
 }
-object INPUT  extends Direction("input") { override def flip: Direction = OUTPUT }
-object OUTPUT extends Direction("output") { override def flip: Direction = INPUT }
-object NO_DIR extends Direction("?") { override def flip: Direction = NO_DIR }
+object Direction {
+  object Input  extends Direction("input") { override def flip: Direction = Output }
+  object Output extends Direction("output") { override def flip: Direction = Input }
+}
 
 @deprecated("debug doesn't do anything in Chisel3 as no pruning happens in the frontend", "chisel3")
 object debug {  // scalastyle:ignore object.name
   def apply (arg: Data): Data = arg
 }
 
-/** Mixing in this trait flips the direction of an Aggregate. */
-trait Flipped extends Data {
-  this.overrideDirection(_.flip, !_)
+object DataMirror {
+  def widthOf(target: Data): Width = target.width
+}
+
+/**
+* Input, Output, and Flipped are used to define the directions of Module IOs.
+*
+* Note that they do not currently call target to be a newType or cloneType.
+* This is nominally for performance reasons to avoid too many extra copies when
+* something is flipped multiple times.
+*
+* Thus, an error will be thrown if these are used on bound Data
+*/
+object Input {
+  def apply[T<:Data](target: T): T =
+    Binding.bind(target, InputBinder, "Error: Cannot set as input ")
+}
+object Output {
+  def apply[T<:Data](target: T): T =
+    Binding.bind(target, OutputBinder, "Error: Cannot set as output ")
+}
+object Flipped {
+  def apply[T<:Data](target: T): T =
+    Binding.bind(target, FlippedBinder, "Error: Cannot flip ")
+}
+
+object Data {
+  /**
+  * This function returns true if the FIRRTL type of this Data should be flipped
+  * relative to other nodes.
+  *
+  * Note that the current scheme only applies Flip to Elements or Vec chains of
+  * Elements.
+  *
+  * A Bundle is never marked flip, instead preferring its root fields to be marked
+  *
+  * The Vec check is due to the fact that flip must be factored out of the vec, ie:
+  * must have flip field: Vec(UInt) instead of field: Vec(flip UInt)
+  */
+  private[Chisel] def isFlipped(target: Data): Boolean = target match {
+    case (element: Element) => element.binding.direction == Some(Direction.Input)
+    case (vec: Vec[Data @unchecked]) => isFlipped(vec.sample_element)
+    case (bundle: Bundle) => false
+  }
+
+  implicit class AddDirectionToData[T<:Data](val target: T) extends AnyVal {
+    @deprecated("Input(Data) should be used over Data.asInput", "gchisel")
+    def asInput: T = Input(target)
+    @deprecated("Output(Data) should be used over Data.asOutput", "gchisel")
+    def asOutput: T = Output(target)
+    @deprecated("Flipped(Data) should be used over Data.flip", "gchisel")
+    def asFlip: T = Flipped(target)
+  }
 }
 
 /** This forms the root of the type system for wire data types. The data value
@@ -29,44 +80,48 @@ trait Flipped extends Data {
   * time) of bits, and must have methods to pack / unpack structured data to /
   * from bits.
   */
-abstract class Data(dirArg: Direction) extends HasId {
-  def dir: Direction = dirVar
-
-  // Sucks this is mutable state, but cloneType doesn't take a Direction arg
-  private var isFlipVar = dirArg == INPUT
-  private var dirVar = dirArg
-  private[Chisel] def isFlip = isFlipVar
-
-  private[Chisel] def overrideDirection(newDir: Direction => Direction,
-                                        newFlip: Boolean => Boolean): this.type = {
-    this.isFlipVar = newFlip(this.isFlipVar)
-    for (field <- this.flatten)
-      (field: Data).dirVar = newDir((field: Data).dirVar)
-    this
-  }
-  def asInput: this.type = cloneType.overrideDirection(_ => INPUT, _ => true)
-  def asOutput: this.type = cloneType.overrideDirection(_ => OUTPUT, _ => false)
-  def flip(): this.type = cloneType.overrideDirection(_.flip, !_)
+abstract class Data extends HasId {
+  // Return ALL elements at root of this type.
+  // Contasts with flatten, which returns just Bits
+  private[Chisel] def allElements: Seq[Element]
 
   private[Chisel] def badConnect(that: Data): Unit =
     throwException(s"cannot connect ${this} and ${that}")
-  private[Chisel] def connect(that: Data): Unit =
-    pushCommand(Connect(this.lref, that.ref))
-  private[Chisel] def bulkConnect(that: Data): Unit =
-    pushCommand(BulkConnect(this.lref, that.lref))
+  private[Chisel] def connect(that: Data): Unit = {
+    Binding.checkSynthesizable(this, s"'this' ($this)")
+    Binding.checkSynthesizable(that, s"'that' ($that)")
+    try {
+      MonoConnect.connect(this, that, Builder.forcedModule)
+    } catch {
+      case MonoConnect.MonoConnectException(message) =>
+        throw new Exception(
+          s"Connection between sink ($this) and source ($that) failed @$message"
+        )
+    }
+  }
+  private[Chisel] def bulkConnect(that: Data): Unit = {
+    Binding.checkSynthesizable(this, s"'this' ($this)")
+    Binding.checkSynthesizable(that, s"'that' ($that)")
+    try {
+      BiConnect.connect(this, that, Builder.forcedModule)
+    } catch {
+      case BiConnect.BiConnectException(message) =>
+        throw new Exception(
+          s"Connection between left ($this) and source ($that) failed @$message"
+        )
+    }
+  }
   private[Chisel] def lref: Node = Node(this)
   private[Chisel] def ref: Arg = if (isLit) litArg.get else lref
-  private[Chisel] def cloneTypeWidth(width: Width): this.type
   private[Chisel] def toType: String
 
-  def := (that: Data): Unit = this badConnect that
-  def <> (that: Data): Unit = this badConnect that
-  def cloneType: this.type
+  final def := (that: Data): Unit = this connect that
+  final def <> (that: Data): Unit = this bulkConnect that
   def litArg(): Option[LitArg] = None
   def litValue(): BigInt = litArg.get.num
   def isLit(): Boolean = litArg.isDefined
 
-  def width: Width
+  private[Chisel] def width: Width
   final def getWidth: Int = width.get
 
   // While this being in the Data API doesn't really make sense (should be in
@@ -94,11 +149,8 @@ abstract class Data(dirArg: Direction) extends HasId {
     var i = 0
     val wire = Wire(this.cloneType)
     val bits =
-      if (n.width.known && n.width.get >= wire.width.get) {
-        n
-      } else {
-        Wire(n.cloneTypeWidth(wire.width), init = n)
-      }
+      if (n.width.known && n.width.get >= wire.width.get) n
+      else Wire(n.cloneTypeWidth(wire.width), init = n)
     for (x <- wire.flatten) {
       x := bits(i + x.getWidth-1, i)
       i += x.getWidth
@@ -111,6 +163,19 @@ abstract class Data(dirArg: Direction) extends HasId {
     * This performs the inverse operation of fromBits(Bits).
     */
   def toBits(): UInt = SeqUtils.asUInt(this.flatten)
+
+  //TODO(twigg): Remove cloneTypeWidth, it doesn't compose for aggregates....
+  private[Chisel] def cloneTypeWidth(width: Width): this.type
+
+  protected def cloneType: this.type
+  final def newType: this.type = {
+    val clone = this.cloneType
+    //TODO(twigg): Do recursively for better error messages
+    for((clone_elem, source_elem) <- clone.allElements zip this.allElements) {
+      clone_elem.binding = UnboundBinding(source_elem.binding.direction)
+    }
+    clone
+  }
 }
 
 object Wire {
@@ -125,28 +190,29 @@ object Wire {
 
   private def makeWire[T <: Data](t: T, init: T): T = {
     val x = Reg.makeType(t, null.asInstanceOf[T], init)
+
+    // Bind each element of x to being a Wire
+    Binding.bind(x, WireBinder(Builder.forcedModule), "Error: t")
+
     pushCommand(DefWire(x))
     pushCommand(DefInvalid(x.ref))
     if (init != null) {
+      Binding.checkSynthesizable(init, s"'init' ($init)")
       x := init
     }
+
     x
   }
 }
 
 object Clock {
-  def apply(dir: Direction = NO_DIR): Clock = new Clock(dir)
+  def apply(): Clock = new Clock
 }
 
 // TODO: Document this.
-sealed class Clock(dirArg: Direction) extends Element(dirArg, Width(1)) {
-  def cloneType: this.type = Clock(dirArg).asInstanceOf[this.type]
+sealed class Clock extends Element(Width(1)) {
+  def cloneType: this.type = Clock().asInstanceOf[this.type]
   private[Chisel] override def flatten: IndexedSeq[Bits] = IndexedSeq()
   private[Chisel] def cloneTypeWidth(width: Width): this.type = cloneType
   private[Chisel] def toType = "Clock"
-
-  override def := (that: Data): Unit = that match {
-    case _: Clock => this connect that
-    case _ => this badConnect that
-  }
 }

--- a/src/main/scala/Chisel/Driver.scala
+++ b/src/main/scala/Chisel/Driver.scala
@@ -110,12 +110,12 @@ object Driver extends BackendCompilationUtilities {
     */
   def elaborate[T <: Module](gen: () => T): Circuit = Builder.build(Module(gen()))
 
-  def emit[T <: Module](gen: () => T): String = elaborate(gen).emit
+  def emit[T <: Module](gen: () => T): String = Emitter.emit(elaborate(gen))
 
   def dumpFirrtl(ir: Circuit, optName: Option[File]): File = {
     val f = optName.getOrElse(new File(ir.name + ".fir"))
     val w = new FileWriter(f)
-    w.write(ir.emit)
+    w.write(Emitter.emit(ir))
     w.close()
     f
   }
@@ -129,5 +129,5 @@ object Driver extends BackendCompilationUtilities {
     }
   }
 
-  def targetDir(): String = { target_dir.get }
+  def targetDir(): String = { target_dir.getOrElse(new File(".").getCanonicalPath) }
 }

--- a/src/main/scala/Chisel/ImplicitConversions.scala
+++ b/src/main/scala/Chisel/ImplicitConversions.scala
@@ -3,6 +3,6 @@
 package Chisel
 
 object ImplicitConversions {
-  implicit def intToUInt(x: Int): UInt = UInt(x)
-  implicit def booleanToBool(x: Boolean): Bool = Bool(x)
+  implicit def intToUInt(x: Int): UInt = UInt.Lit(x)
+  implicit def booleanToBool(x: Boolean): Bool = Bool.Lit(x)
 }

--- a/src/main/scala/Chisel/Module.scala
+++ b/src/main/scala/Chisel/Module.scala
@@ -6,8 +6,8 @@ import scala.collection.mutable.{ArrayBuffer, HashSet}
 
 import internal._
 import internal.Builder.pushCommand
-import internal.Builder.dynamicContext
-import internal.firrtl._
+import internal.firrtl
+import internal.firrtl.{Command, Component, DefInstance, DefInvalid, ModuleIO}
 
 object Module {
   /** A wrapper method that all Module instantiations must be wrapped in
@@ -18,14 +18,20 @@ object Module {
     * @return the input module `m` with Chisel metadata properly set
     */
   def apply[T <: Module](bc: => T): T = {
-    val parent = dynamicContext.currentModule
-    val m = bc.setRefs()
+    val parent: Option[Module] = Builder.currentModule
+    val m = bc.setRefs() // This will set currentModule!
     m._commands.prepend(DefInvalid(m.io.ref)) // init module outputs
-    dynamicContext.currentModule = parent
+    Builder.currentModule = parent // Back to parent!
+
     val ports = m.computePorts
     Builder.components += Component(m, m.name, ports, m._commands)
-    pushCommand(DefInstance(m, ports))
-    m.setupInParent()
+    // Avoid referencing 'parent' in top module
+    if(!Builder.currentModule.isEmpty) {
+      pushCommand(DefInstance(m, ports))
+      m.setupInParent()
+    }
+
+    m
   }
 }
 
@@ -38,16 +44,45 @@ object Module {
 abstract class Module(
   override_clock: Option[Clock]=None, override_reset: Option[Bool]=None)
 extends HasId {
-  // _clock and _reset can be clock and reset in these 2ary constructors
-  // once chisel2 compatibility issues are resolved
-  def this(_clock: Clock) = this(Some(_clock), None)
-  def this(_reset: Bool)  = this(None, Some(_reset))
-  def this(_clock: Clock, _reset: Bool) = this(Some(_clock), Some(_reset))
+  def this(clock: Clock) = this(Option(clock), None)
+  def this(reset: Bool)  = this(None, Option(reset))
+  def this(clock: Clock, reset: Bool) = this(Option(clock), Option(reset))
+
+  // This function binds the iodef as a port in the hardware graph
+  private[Chisel] def Port[T<:Data](iodef: T): iodef.type = {
+    // Bind each element of the iodef to being a Port
+    Binding.bind(iodef, PortBinder(this), "Error: iodef")
+    iodef
+  }
+
+  private[this] var ioDefined: Boolean = false
+
+  /**
+   * This must wrap the datatype used to set the io field of any Module.
+   * i.e. All concrete modules must have defined io in this form:
+   * [lazy] val io[: io type] = IO(...[: io type])
+   *
+   * Items in [] are optional.
+   *
+   * The granted iodef WILL NOT be cloned (to allow for more seamless use of
+   * anonymous Bundles in the IO) and thus CANNOT have been bound to any logic.
+   * This will error if any node is bound (e.g. due to logic in a Bundle
+   * constructor, which is considered improper).
+   *
+   * TODO(twigg): Specifically walk the Data definition to call out which nodes
+   * are problematic.
+   */
+  def IO[T<:Data](iodef: T): iodef.type = {
+    require(!ioDefined, "Another IO definition for this module was already declared!")
+    ioDefined = true
+
+    Port(iodef)
+  }
 
   private[Chisel] val _namespace = Builder.globalNamespace.child
   private[Chisel] val _commands = ArrayBuffer[Command]()
   private[Chisel] val _ids = ArrayBuffer[HasId]()
-  dynamicContext.currentModule = Some(this)
+  Builder.currentModule = Some(this)
 
   /** Name of the instance. */
   val name = Builder.globalNamespace.name(getClass.getName.split('.').last)
@@ -56,8 +91,8 @@ extends HasId {
     * connections in and out of a Module may only go through `io` elements.
     */
   def io: Bundle
-  val clock = Clock(INPUT)
-  val reset = Bool(INPUT)
+  val clock = Port(Input(Clock()))
+  val reset = Port(Input(Bool()))
 
   private[Chisel] def addId(d: HasId) { _ids += d }
 
@@ -65,10 +100,13 @@ extends HasId {
     ("clk", clock), ("reset", reset), ("io", io)
   )
 
-  private[Chisel] def computePorts = for((name, port) <- ports) yield {
-    val bundleDir = if (port.isFlip) INPUT else OUTPUT
-    Port(port, if (port.dir == NO_DIR) bundleDir else port.dir)
-  }
+  private[Chisel] def computePorts: Seq[firrtl.Port] =
+    for((name, port) <- ports) yield {
+      // Port definitions need to know input or output at top-level.
+      // By FIRRTL semantics, 'flipped' becomes an Input
+      val direction = if(Data.isFlipped(port)) Direction.Input else Direction.Output
+      firrtl.Port(port, direction)
+    }
 
   private[Chisel] def setupInParent(): this.type = _parent match {
     case Some(p) => {

--- a/src/main/scala/Chisel/SeqUtils.scala
+++ b/src/main/scala/Chisel/SeqUtils.scala
@@ -17,11 +17,11 @@ private[Chisel] object SeqUtils {
   /** Counts the number of true Bools in a Seq */
   def count(in: Seq[Bool]): UInt = {
     if (in.size == 0) {
-      UInt(0)
+      0.asUInt
     } else if (in.size == 1) {
       in.head
     } else {
-      count(in.slice(0, in.size/2)) + (UInt(0) ## count(in.slice(in.size/2, in.size)))
+      count(in.slice(0, in.size/2)) + (0.asUInt ## count(in.slice(in.size/2, in.size)))
     }
   }
 
@@ -39,7 +39,7 @@ private[Chisel] object SeqUtils {
     if (in.tail.isEmpty) {
       in.head._2
     } else {
-      val masked = for ((s, i) <- in) yield Mux(s, i.toBits, Bits(0))
+      val masked = for ((s, i) <- in) yield Mux(s, i.toBits, 0.asUInt)
       val width = in.map(_._2.width).reduce(_ max _)
       in.head._2.cloneTypeWidth(width).fromBits(masked.reduceLeft(_|_))
     }

--- a/src/main/scala/Chisel/When.scala
+++ b/src/main/scala/Chisel/When.scala
@@ -15,9 +15,9 @@ object when {  // scalastyle:ignore object.name
     *
     * @example
     * {{{
-    * when ( myData === UInt(3) ) {
+    * when ( myData === 3.asUInt ) {
     *   // Some logic to run when myData equals 3.
-    * } .elsewhen ( myData === UInt(1) ) {
+    * } .elsewhen ( myData === 1.asUInt ) {
     *   // Some logic to run when myData equals 1.
     * } .otherwise {
     *   // Some logic to run when myData is neither 3 nor 1.

--- a/src/main/scala/Chisel/internal/BiConnect.scala
+++ b/src/main/scala/Chisel/internal/BiConnect.scala
@@ -1,0 +1,186 @@
+package Chisel
+package internal
+
+/**
+* BiConnect.connect executes a bidirectional connection element-wise.
+*
+* Note that the arguments are left and right (not source and sink) so the
+* intent is for the operation to be commutative.
+*
+* The connect operation will recurse down the left Data (with the right Data).
+* An exception will be thrown if a movement through the left cannot be matched
+* in the right (or if the right side has extra fields).
+*
+* See elemConnect for details on how the root connections are issued.
+*
+*/
+
+object BiConnect {
+  // These are all the possible exceptions that can be thrown.
+  case class BiConnectException(message: String) extends Exception(message)
+  // These are from element-level connection
+  def BothDriversException =
+    BiConnectException(": Both Left and Right are drivers")
+  def NeitherDriverException =
+    BiConnectException(": Neither Left nor Right is a driver")
+  def UnknownDriverException =
+    BiConnectException(": Locally unclear whether Left or Right (both internal)")
+  def UnknownRelationException =
+    BiConnectException(": Left or Right unavailable to current module.")
+  // These are when recursing down aggregate types
+  def MismatchedVecException =
+    BiConnectException(": Left and Right are different length Vecs.")
+  def MissingLeftFieldException(field: String) =
+    BiConnectException(s".$field: Left Bundle missing field ($field).")
+  def MissingRightFieldException(field: String) =
+    BiConnectException(s": Right Bundle missing field ($field).")
+  def MismatchedException(left: String, right: String) =
+    BiConnectException(s": Left ($left) and Right ($right) have different types.")
+
+  /** This function is what recursively tries to connect a left and right together
+  *
+  * There is some cleverness in the use of internal try-catch to catch exceptions
+  * during the recursive decent and then rethrow them with extra information added.
+  * This gives the user a 'path' to where in the connections things went wrong.
+  */
+  def connect(left: Data, right: Data, context_mod: Module): Unit =
+    (left, right) match {
+      // Handle element case (root case)
+      case (left_e: Element, right_e: Element) => {
+        elemConnect(left_e, right_e, context_mod)
+        // TODO(twigg): Verify the element-level classes are connectable
+      }
+      // Handle Vec case
+      case (left_v: Vec[Data @unchecked], right_v: Vec[Data @unchecked]) => {
+        if(left_v.length != right_v.length) { throw MismatchedVecException }
+        for(idx <- 0 until left_v.length) {
+          try {
+            connect(left_v(idx), right_v(idx), context_mod)
+          } catch {
+            case BiConnectException(message) => throw BiConnectException(s"($idx)$message")
+          }
+        }
+      }
+      // Handle Bundle case
+      case (left_b: Bundle, right_b: Bundle) => {
+        // Verify right has no extra fields that left doesn't have
+        for((field, right_sub) <- right_b.elements) {
+          if(!left_b.elements.isDefinedAt(field)) throw MissingLeftFieldException(field)
+        }
+        // For each field in left, descend with right
+        for((field, left_sub) <- left_b.elements) {
+          try {
+            right_b.elements.get(field) match {
+              case Some(right_sub) => connect(left_sub, right_sub, context_mod)
+              case None => throw MissingRightFieldException(field)
+            }
+          } catch {
+            case BiConnectException(message) => throw BiConnectException(s".$field$message")
+          }
+        }
+      }
+      // Left and right are different subtypes of Data so fail
+      case (left, right) => throw MismatchedException(left.toString, right.toString)
+    }
+
+  // These functions (finally) issue the connection operation
+  // Issue with right as sink, left as source
+  private def issueConnectL2R(left: Element, right: Element): Unit = {
+    Builder.pushCommand(firrtl.Connect(right.lref, left.ref))
+  }
+  // Issue with left as sink, right as source
+  private def issueConnectR2L(left: Element, right: Element): Unit = {
+    Builder.pushCommand(firrtl.Connect(left.lref, right.ref))
+  }
+
+  // This function checks if element-level connection operation allowed.
+  // Then it either issues it or throws the appropriate exception.
+  def elemConnect(left: Element, right: Element, context_mod: Module): Unit = {
+    import Direction.{Input, Output} // Using extensively so import these
+    // If left or right have no location, assume in context module
+    // This can occur if one of them is a literal, unbound will error previously
+    val left_mod: Module  = left.binding.location.getOrElse(context_mod)
+    val right_mod: Module = right.binding.location.getOrElse(context_mod)
+
+    val left_direction: Option[Direction] = left.binding.direction
+    val right_direction: Option[Direction] = right.binding.direction
+    // None means internal
+
+    // CASE: Context is same module as left node and right node is in a child module
+    if( (left_mod == context_mod) &&
+        (right_mod._parent.map(_ == context_mod).getOrElse(false)) ) {
+      // Thus, right node better be a port node and thus have a direction hint
+      (left_direction, right_direction) match {
+        //    CURRENT MOD   CHILD MOD
+        case (Some(Input),  Some(Input))  => issueConnectL2R(left, right)
+        case (None,         Some(Input))  => issueConnectL2R(left, right)
+
+        case (Some(Output), Some(Output)) => issueConnectR2L(left, right)
+        case (None,         Some(Output)) => issueConnectR2L(left, right)
+
+        case (Some(Input),  Some(Output)) => throw BothDriversException
+        case (Some(Output), Some(Input))  => throw NeitherDriverException
+        case (_,            None)         => throw UnknownRelationException
+      }
+    }
+
+    // CASE: Context is same module as right node and left node is in child module
+    else if( (right_mod == context_mod) &&
+             (left_mod._parent.map(_ == context_mod).getOrElse(false)) ) {
+      // Thus, left node better be a port node and thus have a direction hint
+      (left_direction, right_direction) match {
+        //    CHILD MOD     CURRENT MOD
+        case (Some(Input),  Some(Input))  => issueConnectR2L(left, right)
+        case (Some(Input),  None)         => issueConnectR2L(left, right)
+
+        case (Some(Output), Some(Output)) => issueConnectL2R(left, right)
+        case (Some(Output), None)         => issueConnectL2R(left, right)
+
+        case (Some(Input),  Some(Output)) => throw NeitherDriverException
+        case (Some(Output), Some(Input))  => throw BothDriversException
+        case (None, _)                    => throw UnknownRelationException
+      }
+    }
+
+    // CASE: Context is same module that both left node and right node are in
+    else if( (context_mod == left_mod) && (context_mod == right_mod) ) {
+      (left_direction, right_direction) match {
+        //    CURRENT MOD   CURRENT MOD
+        case (Some(Input),  Some(Output)) => issueConnectL2R(left, right)
+        case (Some(Input),  None)         => issueConnectL2R(left, right)
+        case (None,         Some(Output)) => issueConnectL2R(left, right)
+
+        case (Some(Output), Some(Input))  => issueConnectR2L(left, right)
+        case (Some(Output), None)         => issueConnectR2L(left, right)
+        case (None,         Some(Input))  => issueConnectR2L(left, right)
+
+        case (Some(Input),  Some(Input))  => throw BothDriversException
+        case (Some(Output), Some(Output)) => throw NeitherDriverException
+        case (None,         None)         => throw UnknownDriverException
+      }
+    }
+
+    // CASE: Context is the parent module of both the module containing left node
+    //                                        and the module containing right node
+    //   Note: This includes case when left and right in same module but in parent
+    else if( (left_mod._parent.map(_ == context_mod).getOrElse(false)) &&
+             (right_mod._parent.map(_ == context_mod).getOrElse(false))
+    ) {
+      // Thus both nodes must be ports and have a direction hint
+      (left_direction, right_direction) match {
+        //    CHILD MOD     CHILD MOD
+        case (Some(Input),  Some(Output)) => issueConnectR2L(left, right)
+        case (Some(Output), Some(Input))  => issueConnectL2R(left, right)
+
+        case (Some(Input),  Some(Input))  => throw NeitherDriverException
+        case (Some(Output), Some(Output)) => throw BothDriversException
+        case (_, None)                    => throw UnknownRelationException
+        case (None, _)                    => throw UnknownRelationException
+      }
+    }
+
+    // Not quite sure where left and right are compared to current module
+    // so just error out
+    else throw UnknownRelationException
+  }
+}

--- a/src/main/scala/Chisel/internal/Binder.scala
+++ b/src/main/scala/Chisel/internal/Binder.scala
@@ -1,0 +1,65 @@
+package Chisel
+package internal
+
+/**
+* A Binder is a function from UnboundBinding to some Binding.
+*
+* These are used exclusively by Binding.bind and sealed in order to keep
+* all of them in one place. There are two flavors of Binders:
+* Non-terminal (returns another UnboundBinding): These are used to reformat an
+*   UnboundBinding (like setting direction) before it is terminally bound.
+* Terminal (returns any other Binding): Due to the nature of Bindings, once a
+*   Data is bound to anything but an UnboundBinding, it is forever locked to
+*   being that type (as it now represents something in the hardware graph).
+*
+* Note that some Binders require extra arguments to be constructed, like the
+* enclosing Module.
+*/
+
+sealed trait Binder[Out <: Binding] extends Function1[UnboundBinding, Out]{
+  def apply(in: UnboundBinding): Out
+}
+
+// THE NON-TERMINAL BINDERS
+// These 'rebind' to another unbound node of different direction!
+case object InputBinder extends Binder[UnboundBinding] {
+  def apply(in: UnboundBinding) = UnboundBinding(Some(Direction.Input))
+}
+case object OutputBinder extends Binder[UnboundBinding] {
+  def apply(in: UnboundBinding) = UnboundBinding(Some(Direction.Output))
+}
+case object FlippedBinder extends Binder[UnboundBinding] {
+  def apply(in: UnboundBinding) = UnboundBinding(in.direction.map(_.flip))
+  // TODO(twigg): flipping a None should probably be a warning/error
+}
+// The need for this should be transient.
+case object NoDirectionBinder extends Binder[UnboundBinding] {
+  def apply(in: UnboundBinding) = UnboundBinding(None)
+}
+
+// THE TERMINAL BINDERS
+case object LitBinder extends Binder[LitBinding] {
+  def apply(in: UnboundBinding) = LitBinding()
+}
+
+case class MemoryPortBinder(enclosure: Module) extends Binder[MemoryPortBinding] {
+  def apply(in: UnboundBinding) = MemoryPortBinding(enclosure)
+}
+
+case class OpBinder(enclosure: Module) extends Binder[OpBinding] {
+  def apply(in: UnboundBinding) = OpBinding(enclosure)
+}
+
+// Notice how PortBinder uses the direction of the UnboundNode
+case class PortBinder(enclosure: Module) extends Binder[PortBinding] {
+  def apply(in: UnboundBinding) = PortBinding(enclosure, in.direction)
+}
+
+case class RegBinder(enclosure: Module) extends Binder[RegBinding] {
+  def apply(in: UnboundBinding) = RegBinding(enclosure)
+}
+
+case class WireBinder(enclosure: Module) extends Binder[WireBinding] {
+  def apply(in: UnboundBinding) = WireBinding(enclosure)
+}
+

--- a/src/main/scala/Chisel/internal/Binding.scala
+++ b/src/main/scala/Chisel/internal/Binding.scala
@@ -1,0 +1,180 @@
+package Chisel
+package internal
+
+/**
+ * The purpose of a Binding is to indicate what type of hardware 'entity' a
+ * specific Data's leaf Elements is actually bound to. All Data starts as being
+ * Unbound (and the whole point of cloneType is to return an unbound version).
+ * Then, specific API calls take a Data, and return a bound version (either by
+ * binding the original model or cloneType then binding the clone). For example,
+ * Reg[T<:Data](...) returns a T bound to RegBinding.
+ *
+ * It is considered invariant that all Elements of a single Data are bound to
+ * the same concrete type of Binding.
+ *
+ * These bindings can be checked (e.g. checkSynthesizable) to make sure certain
+ * operations are valid. For example, arithemetic operations or connections can
+ * only be executed between synthesizable nodes. These checks are to avoid
+ * undefined reference errors.
+ *
+ * Bindings can carry information about the particular element in the graph it
+ * represents like:
+ * - For ports (and unbound), the 'direction'
+ * - For (relevant) synthesizable nodes, the enclosing Module
+ *
+ * TODO(twigg): Enrich the bindings to carry more information like the hosting
+ * module (when applicable), direction (when applicable), literal info (when
+ * applicable). Can ensure applicable data only stored on relevant nodes. e.g.
+ * literal info on LitBinding, direction info on UnboundBinding and PortBinding,
+ * etc.
+ *
+ * TODO(twigg): Currently, bindings only apply at the Element level and an
+ * Aggregate is considered bound via its elements. May be appropriate to allow
+ * Aggregates to be bound along with the Elements. However, certain literal and
+ * port direction information doesn't quite make sense in aggregates. This would
+ * elegantly handle the empty Vec or Bundle problem though.
+ *
+ * TODO(twigg): Binding is currently done via allElements. It may be more
+ * elegant if this was instead done as a more explicit tree walk as that allows
+ * for better errors.
+ */
+
+object Binding {
+  // Two bindings are 'compatible' if they are the same type.
+  // Check currently kind of weird: just ensures same class
+  private def compatible(a: Binding, b: Binding): Boolean = a.getClass == b.getClass
+  private def compatible(nodes: Seq[Binding]): Boolean =
+    if(nodes.size > 1)
+      (for((a,b) <- nodes zip nodes.tail) yield compatible(a,b))
+      .fold(true)(_&&_)
+    else true
+
+  case class BindingException(message: String) extends Exception(message)
+  def AlreadyBoundException(binding: String) = BindingException(s": Already bound to $binding")
+  def NotSynthesizableException = BindingException(s": Not bound to synthesizable node, currently only Type description")
+
+  // This recursively walks down the Data tree to look at all the leaf 'Element's
+  // Will build up an error string in case something goes wrong
+  // TODO(twigg): Make member function of Data.
+  //   Allows oddities like sample_element to be better hidden
+  private def walkToBinding(target: Data, checker: Element=>Unit): Unit = target match {
+    case (element: Element) => checker(element)
+    case (vec: Vec[Data @unchecked]) => {
+      try walkToBinding(vec.sample_element, checker)
+      catch {
+        case BindingException(message) => throw BindingException(s"(*)$message")
+      }
+      for(idx <- 0 until vec.length) {
+        try walkToBinding(vec(idx), checker)
+        catch {
+          case BindingException(message) => throw BindingException(s"($idx)$message")
+        }
+      }
+    }
+    case (bundle: Bundle) => {
+      for((field, subelem) <- bundle.elements) {
+        try walkToBinding(subelem, checker)
+        catch {
+          case BindingException(message) => throw BindingException(s".$field$message")
+        }
+      }
+    }
+  }
+
+  // Use walkToBinding to actually rebind the node type
+  def bind[T<:Data](target: T, binder: Binder[_<:Binding], error_prelude: String): target.type = {
+    try walkToBinding(
+      target,
+      element => element.binding match {
+        case unbound @ UnboundBinding(_) => {
+          element.binding = binder(unbound)
+        }
+        case binding => throw AlreadyBoundException(binding.toString)
+      }
+    )
+    catch {
+      case BindingException(message) => throw BindingException(s"$error_prelude$message")
+    }
+    target
+  }
+
+  // Excepts if any root element is already bound
+  def checkUnbound(target: Data, error_prelude: String): Unit = {
+    try walkToBinding(
+      target,
+      element => element.binding match {
+        case unbound @ UnboundBinding(_) => {}
+        case binding => throw AlreadyBoundException(binding.toString)
+      }
+    )
+    catch {
+      case BindingException(message) => throw BindingException(s"$error_prelude$message")
+    }
+  }
+
+  // Excepts if any root element is unbound and thus not on the hardware graph
+  def checkSynthesizable(target: Data, error_prelude: String): Unit =
+    try walkToBinding(
+      target,
+      element => element.binding match {
+        case SynthesizableBinding() => {} // OK
+        case binding => throw NotSynthesizableException
+      }
+    )
+    catch {
+      case BindingException(message) => throw BindingException(s"$error_prelude$message")
+    }
+}
+
+// Location refers to 'where' in the Module hierarchy this lives
+sealed trait Binding {
+  def location: Option[Module]
+  def direction: Option[Direction]
+}
+
+// Constrained-ness refers to whether 'bound by Module boundaries'
+// An unconstrained binding, like a literal, can be read by everyone
+sealed trait UnconstrainedBinding extends Binding {
+  def location = None
+}
+// A constrained binding can only be read/written by specific modules
+// Location will track where this Module is
+sealed trait ConstrainedBinding extends Binding {
+  def enclosure: Module
+  def location = Some(enclosure)
+}
+
+// An undirectioned binding means the element represents an internal node
+//   with no meaningful concept of a direction
+sealed trait UndirectionedBinding extends Binding { def direction = None }
+
+// This is the default binding, represents data not yet positioned in the graph
+case class UnboundBinding(direction: Option[Direction])
+    extends Binding with UnconstrainedBinding
+
+
+// A synthesizable binding is 'bound into' the hardware graph
+object SynthesizableBinding {
+  def unapply(target: Binding): Boolean = target.isInstanceOf[SynthesizableBinding]
+  // Type check OK because Binding and SynthesizableBinding is sealed
+}
+sealed trait SynthesizableBinding extends Binding
+case class LitBinding() // will eventually have literal info
+    extends SynthesizableBinding with UnconstrainedBinding with UndirectionedBinding
+
+case class MemoryPortBinding(enclosure: Module)
+    extends SynthesizableBinding with ConstrainedBinding with UndirectionedBinding
+
+// TODO(twigg): Ops between unenclosed nodes can also be unenclosed
+// However, Chisel currently binds all op results to a module
+case class OpBinding(enclosure: Module)
+    extends SynthesizableBinding with ConstrainedBinding with UndirectionedBinding
+
+case class PortBinding(enclosure: Module, direction: Option[Direction])
+    extends SynthesizableBinding with ConstrainedBinding
+
+case class RegBinding(enclosure: Module)
+    extends SynthesizableBinding with ConstrainedBinding with UndirectionedBinding
+
+case class WireBinding(enclosure: Module)
+    extends SynthesizableBinding with ConstrainedBinding with UndirectionedBinding

--- a/src/main/scala/Chisel/internal/Builder.scala
+++ b/src/main/scala/Chisel/internal/Builder.scala
@@ -41,11 +41,11 @@ private[Chisel] class IdGen {
 }
 
 private[Chisel] trait HasId {
-  private[Chisel] def _onModuleClose {} // scalastyle:ignore method.name
-  private[Chisel] val _parent = Builder.dynamicContext.currentModule
+  private[Chisel] def _onModuleClose: Unit = {} // scalastyle:ignore method.name
+  private[Chisel] val _parent: Option[Module] = Builder.currentModule
   _parent.foreach(_.addId(this))
 
-  private[Chisel] val _id = Builder.idGen.next
+  private[Chisel] val _id: Long = Builder.idGen.next
   override def hashCode: Int = _id.toInt
   override def equals(that: Any): Boolean = that match {
     case x: HasId => _id == x._id
@@ -93,17 +93,36 @@ private[Chisel] class DynamicContext {
 private[Chisel] object Builder {
   // All global mutable state must be referenced via dynamicContextVar!!
   private val dynamicContextVar = new DynamicVariable[Option[DynamicContext]](None)
+  private def dynamicContext: DynamicContext =
+    dynamicContextVar.value.getOrElse(new DynamicContext)
 
-  def dynamicContext: DynamicContext = dynamicContextVar.value.get
   def idGen: IdGen = dynamicContext.idGen
   def globalNamespace: Namespace = dynamicContext.globalNamespace
   def components: ArrayBuffer[Component] = dynamicContext.components
 
+  def currentModule: Option[Module] = dynamicContext.currentModule
+  def currentModule_=(target: Option[Module]): Unit = {
+    dynamicContext.currentModule = target
+  }
+  def forcedModule: Module = currentModule match {
+    case Some(module) => module
+    case None => throw new Exception(
+      "Error: Not in a Module. Likely cause: Missed Module() wrap or bare chisel API call."
+      // A bare api call is, e.g. calling Wire() from the scala console).
+    )
+  }
+
+  // TODO(twigg): Ideally, binding checks and new bindings would all occur here
+  // However, rest of frontend can't support this yet.
   def pushCommand[T <: Command](c: T): T = {
-    dynamicContext.currentModule.foreach(_._commands += c)
+    forcedModule._commands += c
     c
   }
-  def pushOp[T <: Data](cmd: DefPrim[T]): T = pushCommand(cmd).id
+  def pushOp[T <: Data](cmd: DefPrim[T]): T = {
+    // Bind each element of the returned Data to being a Op
+    Binding.bind(cmd.id, OpBinder(forcedModule), "Error: During op creation, fresh result")
+    pushCommand(cmd).id
+  }
 
   def errors: ErrorLog = dynamicContext.errors
   def error(m: => String): Unit = errors.error(m)

--- a/src/main/scala/Chisel/internal/MonoConnect.scala
+++ b/src/main/scala/Chisel/internal/MonoConnect.scala
@@ -1,0 +1,168 @@
+package Chisel
+package internal
+
+/**
+* MonoConnect.connect executes a mono-directional connection element-wise.
+*
+* Note that this isn't commutative. There is an explicit source and sink
+* already determined before this function is called.
+*
+* The connect operation will recurse down the left Data (with the right Data).
+* An exception will be thrown if a movement through the left cannot be matched
+* in the right. The right side is allowed to have extra Bundle fields.
+* Vecs must still be exactly the same size.
+*
+* See elemConnect for details on how the root connections are issued.
+*
+* Note that a valid sink must be writable so, one of these must hold:
+* - Is an internal writable node (Reg or Wire)
+* - Is an output of the current module
+* - Is an input of a submodule of the current module
+*
+* Note that a valid source must be readable so, one of these must hold:
+* - Is an internal readable node (Reg, Wire, Op)
+* - Is a literal
+* - Is a port of the current module or submodule of the current module
+*/
+
+object MonoConnect {
+  // These are all the possible exceptions that can be thrown.
+  case class MonoConnectException(message: String) extends Exception(message)
+  // These are from element-level connection
+  def UnreadableSourceException =
+    MonoConnectException(": Source is unreadable from current module.")
+  def UnwritableSinkException =
+    MonoConnectException(": Sink is unwriteable by current module.")
+  def UnknownRelationException =
+    MonoConnectException(": Sink or source unavailable to current module.")
+  // These are when recursing down aggregate types
+  def MismatchedVecException =
+    MonoConnectException(": Sink and Source are different length Vecs.")
+  def MissingFieldException(field: String) =
+    MonoConnectException(s": Source Bundle missing field ($field).")
+  def MismatchedException(sink: String, source: String) =
+    MonoConnectException(s": Sink ($sink) and Source ($source) have different types.")
+
+  /** This function is what recursively tries to connect a sink and source together
+  *
+  * There is some cleverness in the use of internal try-catch to catch exceptions
+  * during the recursive decent and then rethrow them with extra information added.
+  * This gives the user a 'path' to where in the connections things went wrong.
+  */
+  def connect(sink: Data, source: Data, context_mod: Module): Unit =
+    (sink, source) match {
+      // Handle element case (root case)
+      case (sink_e: Element, source_e: Element) => {
+        elemConnect(sink_e, source_e, context_mod)
+        // TODO(twigg): Verify the element-level classes are connectable
+      }
+      // Handle Vec case
+      case (sink_v: Vec[Data @unchecked], source_v: Vec[Data @unchecked]) => {
+        if(sink_v.length != source_v.length) { throw MismatchedVecException }
+        for(idx <- 0 until sink_v.length) {
+          try {
+            connect(sink_v(idx), source_v(idx), context_mod)
+          } catch {
+            case MonoConnectException(message) => throw MonoConnectException(s"($idx)$message")
+          }
+        }
+      }
+      // Handle Bundle case
+      case (sink_b: Bundle, source_b: Bundle) => {
+        // For each field, descend with right
+        for((field, sink_sub) <- sink_b.elements) {
+          try {
+            source_b.elements.get(field) match {
+              case Some(source_sub) => connect(sink_sub, source_sub, context_mod)
+              case None => throw MissingFieldException(field)
+            }
+          } catch {
+            case MonoConnectException(message) => throw MonoConnectException(s".$field$message")
+          }
+        }
+      }
+      // Sink and source are different subtypes of data so fail
+      case (sink, source) => throw MismatchedException(sink.toString, source.toString)
+    }
+
+  // This function (finally) issues the connection operation
+  private def issueConnect(sink: Element, source: Element): Unit = {
+    Builder.pushCommand(firrtl.Connect(sink.lref, source.ref))
+  }
+
+  // This function checks if element-level connection operation allowed.
+  // Then it either issues it or throws the appropriate exception.
+  def elemConnect(sink: Element, source: Element, context_mod: Module): Unit = {
+    import Direction.{Input, Output} // Using extensively so import these
+    // If source has no location, assume in context module
+    // This can occur if is a literal, unbound will error previously
+    val sink_mod: Module   = sink.binding.location.getOrElse(throw UnwritableSinkException)
+    val source_mod: Module = source.binding.location.getOrElse(context_mod)
+
+    val sink_direction: Option[Direction] = sink.binding.direction
+    val source_direction: Option[Direction] = source.binding.direction
+    // None means internal
+
+    // CASE: Context is same module that both left node and right node are in
+    if( (context_mod == sink_mod) && (context_mod == source_mod) ) {
+      (sink_direction, source_direction) match {
+        //    SINK          SOURCE
+        //    CURRENT MOD   CURRENT MOD
+        case (Some(Output), _) => issueConnect(sink, source)
+        case (None,         _) => issueConnect(sink, source)
+        case (Some(Input),  _) => throw UnwritableSinkException
+      }
+    }
+
+    // CASE: Context is same module as sink node and right node is in a child module
+    else if( (sink_mod == context_mod) &&
+             (source_mod._parent.map(_ == context_mod).getOrElse(false)) ) {
+      // Thus, right node better be a port node and thus have a direction
+      (sink_direction, source_direction) match {
+        //    SINK          SOURCE
+        //    CURRENT MOD   CHILD MOD
+        case (None,         Some(Output)) => issueConnect(sink, source)
+        case (None,         Some(Input))  => issueConnect(sink, source)
+        case (Some(Output), Some(Output)) => issueConnect(sink, source)
+        case (Some(Output), Some(Input))  => issueConnect(sink, source)
+        case (_,            None) => throw UnreadableSourceException
+        case (Some(Input),  _)    => throw UnwritableSinkException
+      }
+    }
+
+    // CASE: Context is same module as source node and sink node is in child module
+    else if( (source_mod == context_mod) &&
+             (sink_mod._parent.map(_ == context_mod).getOrElse(false)) ) {
+      // Thus, left node better be a port node and thus have a direction
+      (sink_direction, source_direction) match {
+        //    SINK          SOURCE
+        //    CHILD MOD     CURRENT MOD
+        case (Some(Input),  _) => issueConnect(sink, source)
+        case (Some(Output), _) => throw UnwritableSinkException
+        case (None,         _) => throw UnwritableSinkException
+      }
+    }
+
+    // CASE: Context is the parent module of both the module containing sink node
+    //                                        and the module containing source node
+    //   Note: This includes case when sink and source in same module but in parent
+    else if( (sink_mod._parent.map(_ == context_mod).getOrElse(false)) &&
+             (source_mod._parent.map(_ == context_mod).getOrElse(false))
+    ) {
+      // Thus both nodes must be ports and have a direction
+      (sink_direction, source_direction) match {
+        //    SINK          SOURCE
+        //    CHILD MOD     CHILD MOD
+        case (Some(Input),  Some(Input))  => issueConnect(sink, source)
+        case (Some(Input),  Some(Output)) => issueConnect(sink, source)
+        case (Some(Output), _)            => throw UnwritableSinkException
+        case (_,            None)         => throw UnreadableSourceException
+        case (None,         _)            => throw UnwritableSinkException
+      }
+    }
+
+    // Not quite sure where left and right are compared to current module
+    // so just error out
+    else throw UnknownRelationException
+  }
+}

--- a/src/main/scala/Chisel/internal/firrtl/Emitter.scala
+++ b/src/main/scala/Chisel/internal/firrtl/Emitter.scala
@@ -3,6 +3,10 @@
 package Chisel.internal.firrtl
 import Chisel._
 
+private[Chisel] object Emitter {
+  def emit(circuit: Circuit): String = new Emitter(circuit).toString
+}
+
 private class Emitter(circuit: Circuit) {
   override def toString: String = res.toString
 

--- a/src/main/scala/Chisel/internal/firrtl/IR.scala
+++ b/src/main/scala/Chisel/internal/firrtl/IR.scala
@@ -169,11 +169,9 @@ case class Printf(clk: Arg, formatIn: String, ids: Seq[Arg]) extends Command {
   def format: String = {
     def escaped(x: Char) = {
       require(x.toInt >= 0)
-      if (x == '"' || x == '\\') {
-        s"\\${x}"
-      } else if (x == '\n') {
-        "\\n"
-      } else {
+      if (x == '"' || x == '\\') s"\\${x}"
+      else if (x == '\n') "\\n"
+      else {
         require(x.toInt >= 32) // TODO \xNN once FIRRTL issue #59 is resolved
         x
       }
@@ -182,6 +180,4 @@ case class Printf(clk: Arg, formatIn: String, ids: Seq[Arg]) extends Command {
   }
 }
 
-case class Circuit(name: String, components: Seq[Component]) {
-  def emit: String = new Emitter(this).toString
-}
+case class Circuit(name: String, components: Seq[Component])

--- a/src/main/scala/Chisel/package.scala
+++ b/src/main/scala/Chisel/package.scala
@@ -1,17 +1,64 @@
 package object Chisel {
-  import internal.firrtl.Width
-  implicit class fromBigIntToLiteral(val x: BigInt) extends AnyVal {
-    def U: UInt = UInt(x, Width())
-    def S: SInt = SInt(x, Width())
+  /**
+  * These implicit classes allow one to convert scala.Int|scala.BigInt to
+  * Chisel.UInt|Chisel.SInt by calling .asUInt|.asSInt on them, respectively.
+  * The versions .asUInt(width)|.asSInt(width) are also available to explicitly
+  * mark a width for the new literal.
+  *
+  * Also provides .asBool to scala.Boolean and .asUInt to String
+  *
+  * Note that, for stylistic reasons, one hould avoid extracting immediately
+  * after this call using apply, ie. 0.asUInt(1)(0) due to potential for
+  * confusion (the 1 is a bit length and the 0 is a bit extraction position).
+  * Prefer storing the result and then extracting from it.
+  */
+  implicit class addLiteraltoScalaInt(val target: Int) extends AnyVal {
+    def asUInt() = UInt.Lit(target)
+    def asSInt() = SInt.Lit(target)
+    def asUInt(width: Int) = UInt.Lit(target, width)
+    def asSInt(width: Int) = SInt.Lit(target, width)
+
+    // These were recently added to chisel2/3 but are not to be used internally
+    @deprecated("asUInt should be used over U", "gchisel")
+    def U() = UInt.Lit(target)
+    @deprecated("asSInt should be used over S", "gchisel")
+    def S() = SInt.Lit(target)
+    @deprecated("asUInt should be used over U", "gchisel")
+    def U(width: Int) = UInt.Lit(target, width)
+    @deprecated("asSInt should be used over S", "gchisel")
+    def S(width: Int) = SInt.Lit(target, width)
   }
-  implicit class fromIntToLiteral(val x: Int) extends AnyVal {
-    def U: UInt = UInt(BigInt(x), Width())
-    def S: SInt = SInt(BigInt(x), Width())
+  implicit class addLiteraltoScalaBigInt(val target: BigInt) extends AnyVal {
+    def asUInt() = UInt.Lit(target)
+    def asSInt() = SInt.Lit(target)
+    def asUInt(width: Int) = UInt.Lit(target, width)
+    def asSInt(width: Int) = SInt.Lit(target, width)
+
+    // These were recently added to chisel2/3 but are not to be used internally
+    @deprecated("asUInt should be used over U", "gchisel")
+    def U() = UInt.Lit(target)
+    @deprecated("asSInt should be used over S", "gchisel")
+    def S() = SInt.Lit(target)
+    @deprecated("asUInt should be used over U", "gchisel")
+    def U(width: Int) = UInt.Lit(target, width)
+    @deprecated("asSInt should be used over S", "gchisel")
+    def S(width: Int) = SInt.Lit(target, width)
   }
-  implicit class fromStringToLiteral(val x: String) extends AnyVal {
-    def U: UInt = UInt(x)
+  implicit class addLiteraltoScalaString(val target: String) extends AnyVal {
+    def asUInt() = UInt.Lit(target)
+    def asUInt(width: Int) = UInt.Lit(target, width)
+
+    // These were recently added to chisel2/3 but are not to be used internally
+    @deprecated("asUInt should be used over U", "gchisel")
+    def U() = UInt.Lit(target)
+    @deprecated("asUInt should be used over U", "gchisel")
+    def U(width: Int) = UInt.Lit(target, width)
   }
-  implicit class fromBooleanToLiteral(val x: Boolean) extends AnyVal {
-    def B: Bool = Bool(x)
+  implicit class addLiteraltoScalaBool(val target: Boolean) extends AnyVal {
+    def asBool = Bool.Lit(target)
+
+    // These were recently added to chisel2/3 but are not to be used internally
+    @deprecated("asBool should be used over B", "gchisel")
+    def B = Bool.Lit(target)
   }
 }

--- a/src/main/scala/Chisel/testers/BasicTester.scala
+++ b/src/main/scala/Chisel/testers/BasicTester.scala
@@ -9,7 +9,7 @@ import internal.firrtl._
 
 class BasicTester extends Module {
   // The testbench has no IOs, rather it should communicate using printf, assert, and stop.
-  val io = new Bundle()
+  val io = IO(new Bundle())
 
   def popCount(n: Long): Int = n.toBinaryString.count(_=='1')
 

--- a/src/main/scala/Chisel/util/Arbiter.scala
+++ b/src/main/scala/Chisel/util/Arbiter.scala
@@ -7,9 +7,9 @@ package Chisel
 
 /** An I/O bundle for the Arbiter */
 class ArbiterIO[T <: Data](gen: T, n: Int) extends Bundle {
-  val in  = Vec(n, Decoupled(gen)).flip
-  val out = Decoupled(gen)
-  val chosen = UInt(OUTPUT, log2Up(n))
+  val in  = Flipped(Vec(n, DecoupledIO(gen)))
+  val out = DecoupledIO(gen)
+  val chosen = Output(UInt(log2Up(n)))
 }
 
 /** Arbiter Control determining which producer has access */
@@ -17,15 +17,15 @@ private object ArbiterCtrl
 {
   def apply(request: Seq[Bool]): Seq[Bool] = request.length match {
     case 0 => Seq()
-    case 1 => Seq(Bool(true))
-    case _ => Bool(true) +: request.tail.init.scanLeft(request.head)(_ || _).map(!_)
+    case 1 => Seq(true.asBool)
+    case _ => true.asBool +: request.tail.init.scanLeft(request.head)(_ || _).map(!_)
   }
 }
 
 abstract class LockingArbiterLike[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T => Bool]) extends Module {
   def grant: Seq[Bool]
   def choice: UInt
-  val io = new ArbiterIO(gen, n)
+  val io = IO(new ArbiterIO(gen, n))
 
   io.chosen := choice
   io.out.valid := io.in(io.chosen).valid
@@ -34,17 +34,17 @@ abstract class LockingArbiterLike[T <: Data](gen: T, n: Int, count: Int, needsLo
   if (count > 1) {
     val lockCount = Counter(count)
     val lockIdx = Reg(UInt())
-    val locked = lockCount.value =/= UInt(0)
-    val wantsLock = needsLock.map(_(io.out.bits)).getOrElse(Bool(true))
+    val locked = lockCount.value =/= 0.asUInt
+    val wantsLock = needsLock.map(_(io.out.bits)).getOrElse(true.asBool)
 
-    when (io.out.fire() && wantsLock) {
+    when (io.out.firing && wantsLock) {
       lockIdx := io.chosen
       lockCount.inc()
     }
 
     when (locked) { io.chosen := lockIdx }
     for ((in, (g, i)) <- io.in zip grant.zipWithIndex)
-      in.ready := Mux(locked, lockIdx === UInt(i), g) && io.out.ready
+      in.ready := Mux(locked, lockIdx === i.asUInt, g) && io.out.ready
   } else {
     for ((in, g) <- io.in zip grant)
       in.ready := g && io.out.ready
@@ -53,8 +53,8 @@ abstract class LockingArbiterLike[T <: Data](gen: T, n: Int, count: Int, needsLo
 
 class LockingRRArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T => Bool] = None)
     extends LockingArbiterLike[T](gen, n, count, needsLock) {
-  lazy val lastGrant = RegEnable(io.chosen, io.out.fire())
-  lazy val grantMask = (0 until n).map(UInt(_) > lastGrant)
+  lazy val lastGrant = RegEnable(io.chosen, io.out.firing)
+  lazy val grantMask = (0 until n).map(_.asUInt > lastGrant)
   lazy val validMask = io.in zip grantMask map { case (in, g) => in.valid && g }
 
   override def grant: Seq[Bool] = {
@@ -62,20 +62,20 @@ class LockingRRArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[
     (0 until n).map(i => ctrl(i) && grantMask(i) || ctrl(i + n))
   }
 
-  override lazy val choice = Wire(init=UInt(n-1))
+  override lazy val choice = Wire(init=(n-1).asUInt)
   for (i <- n-2 to 0 by -1)
-    when (io.in(i).valid) { choice := UInt(i) }
+    when (io.in(i).valid) { choice := i.asUInt }
   for (i <- n-1 to 1 by -1)
-    when (validMask(i)) { choice := UInt(i) }
+    when (validMask(i)) { choice := i.asUInt }
 }
 
 class LockingArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T => Bool] = None)
     extends LockingArbiterLike[T](gen, n, count, needsLock) {
   def grant: Seq[Bool] = ArbiterCtrl(io.in.map(_.valid))
 
-  override lazy val choice = Wire(init=UInt(n-1))
+  override lazy val choice = Wire(init=(n-1).asUInt)
   for (i <- n-2 to 0 by -1)
-    when (io.in(i).valid) { choice := UInt(i) }
+    when (io.in(i).valid) { choice := i.asUInt }
 }
 
 /** Hardware module that is used to sequence n producers into 1 consumer.
@@ -99,13 +99,13 @@ class RRArbiter[T <: Data](gen:T, n: Int) extends LockingRRArbiter[T](gen, n, 1)
    consumer.io.in <> arb.io.out
  */
 class Arbiter[T <: Data](gen: T, n: Int) extends Module {
-  val io = new ArbiterIO(gen, n)
+  val io = IO(new ArbiterIO(gen, n))
 
-  io.chosen := UInt(n-1)
+  io.chosen := (n-1).asUInt
   io.out.bits := io.in(n-1).bits
   for (i <- n-2 to 0 by -1) {
     when (io.in(i).valid) {
-      io.chosen := UInt(i)
+      io.chosen := i.asUInt
       io.out.bits := io.in(i).bits
     }
   }

--- a/src/main/scala/Chisel/util/Bitwise.scala
+++ b/src/main/scala/Chisel/util/Bitwise.scala
@@ -38,7 +38,7 @@ object Fill {
   /** Fan out x n times */
   def apply(n: Int, x: Bool): UInt =
     if (n > 1) {
-      UInt(0,n) - x
+      0.asUInt(n) - x
     } else {
       apply(n, x: UInt)
     }
@@ -55,7 +55,7 @@ object Reverse
       // This esoterica improves simulation performance
       var res = in
       var shift = length >> 1
-      var mask = UInt((BigInt(1) << length) - 1, length)
+      var mask = ((BigInt(1) << length) - 1).asUInt(length)
       do {
         mask = mask ^ (mask(length-shift-1,0) << shift)
         res = ((res >> shift) & mask) | ((res(length-shift-1,0) << shift) & ~mask)

--- a/src/main/scala/Chisel/util/CircuitMath.scala
+++ b/src/main/scala/Chisel/util/CircuitMath.scala
@@ -9,17 +9,13 @@ package Chisel
   * An alternative interpretation is it computes the minimum number of bits needed to represent x
   * @example
   * {{{ data_out := Log2(data_in) }}}
-  * @note Truncation is used so Log2(UInt(12412)) = 13*/
+  * @note Truncation is used so Log2(12412.asUInt) = 13*/
 object Log2 {
   /** Compute the Log2 on the least significant n bits of x */
   def apply(x: Bits, width: Int): UInt = {
-    if (width < 2) {
-      UInt(0)
-    } else if (width == 2) {
-      x(1)
-    } else {
-      Mux(x(width-1), UInt(width-1), apply(x, width-1))
-    }
+    if (width < 2) 0.asUInt
+    else if (width == 2) x(1)
+    else Mux(x(width-1), UInt(width-1), apply(x, width-1))
   }
 
   def apply(x: Bits): UInt = apply(x, x.getWidth)

--- a/src/main/scala/Chisel/util/Counter.scala
+++ b/src/main/scala/Chisel/util/Counter.scala
@@ -8,21 +8,21 @@ package Chisel
   */
 class Counter(val n: Int) {
   require(n >= 0)
-  val value = if (n > 1) Reg(init=UInt(0, log2Up(n))) else UInt(0)
+  val value = if (n > 1) Reg(init=0.asUInt(log2Up(n))) else 0.asUInt
   /** Increment the counter, returning whether the counter currently is at the
     * maximum and will wrap. The incremented value is registered and will be
     * visible on the next cycle.
     */
   def inc(): Bool = {
     if (n > 1) {
-      val wrap = value === UInt(n-1)
-      value := value + UInt(1)
+      val wrap = value === (n-1).asUInt
+      value := value + 1.asUInt
       if (!isPow2(n)) {
-        when (wrap) { value := UInt(0) }
+        when (wrap) { value := 0.asUInt }
       }
       wrap
     } else {
-      Bool(true)
+      true.asBool
     }
   }
 }
@@ -31,7 +31,7 @@ class Counter(val n: Int) {
   * Example Usage:
   * {{{ val countOn = Bool(true) // increment counter every clock cycle
   * val myCounter = Counter(countOn, n)
-  * when ( myCounter.value === UInt(3) ) { ... } }}}*/
+  * when ( myCounter.value === 3.asUInt ) { ... } }}}*/
 object Counter
 {
   def apply(n: Int): Counter = new Counter(n)

--- a/src/main/scala/Chisel/util/Decoupled.scala
+++ b/src/main/scala/Chisel/util/Decoupled.scala
@@ -8,71 +8,61 @@ package Chisel
 /** An I/O Bundle with simple handshaking using valid and ready signals for data 'bits'*/
 class DecoupledIO[+T <: Data](gen: T) extends Bundle
 {
-  val ready = Bool(INPUT)
-  val valid = Bool(OUTPUT)
-  val bits  = gen.cloneType.asOutput
-  def fire(dummy: Int = 0): Bool = ready && valid
-  override def cloneType: this.type = new DecoupledIO(gen).asInstanceOf[this.type]
+  val ready = Input(Bool())
+  val valid = Output(Bool())
+  val bits  = Output(gen.newType)
+  override protected def cloneType: this.type = DecoupledIO(gen).asInstanceOf[this.type]
 }
 
-/** Adds a ready-valid handshaking protocol to any interface.
-  * The standard used is that the consumer uses the flipped interface.
-  */
-object Decoupled {
+object DecoupledIO {
+  /** Adds a ready-valid handshaking protocol to any interface.
+    * The standard used is that the consumer uses the flipped interface.
+    */
   def apply[T <: Data](gen: T): DecoupledIO[T] = new DecoupledIO(gen)
-}
 
-/** An I/O bundle for enqueuing data with valid/ready handshaking
-  * Initialization must be handled, if necessary, by the parent circuit
-  */
-class EnqIO[T <: Data](gen: T) extends DecoupledIO(gen)
-{
-  /** push dat onto the output bits of this interface to let the consumer know it has happened.
-    * @param dat the values to assign to bits.
-    * @return    dat.
-    */
-  def enq(dat: T): T = { valid := Bool(true); bits := dat; dat }
+  implicit class AddMethodsToDecoupled[T<:Data](val target: DecoupledIO[T]) extends AnyVal {
+    def firing: Bool = target.ready && target.valid
 
-  /** Initialize this Bundle.  Valid is set to false, and all bits are set to zero.
-    * NOTE: This method of initialization is still being discussed and could change in the
-    * future.
-    */
-  def init(): Unit = {
-    valid := Bool(false)
-    for (io <- bits.flatten)
-      io := UInt(0)
+    /** push dat onto the output bits of this interface to let the consumer know it has happened.
+      * @param dat the values to assign to bits.
+      * @return    dat.
+      */
+    def enq(dat: T): T = {
+      target.valid := true.asBool
+      target.bits := dat
+      dat
+    }
+
+    /** Indicate no enqueue occurs.  Valid is set to false, and all bits are set to zero.
+      */
+    def noenq(): Unit = {
+      target.valid := false.asBool
+      target.bits := target.bits.fromBits(0.asUInt)
+    }
+
+    /** Assert ready on this port and return the associated data bits.
+      * This is typically used when valid has been asserted by the producer side.
+      * @param b ignored
+      * @return the data for this device,
+      */
+    def deq(): T = {
+      target.ready := true.asBool
+      target.bits
+    }
+
+    /** Indicate no dequeue occurs. Ready is set to false
+      */
+    def nodeq(): Unit = {
+      target.ready := false.asBool
+    }
   }
-  override def cloneType: this.type = { new EnqIO(gen).asInstanceOf[this.type]; }
 }
 
-/** An I/O bundle for dequeuing data with valid/ready handshaking.
-  * Initialization must be handled, if necessary, by the parent circuit
-  */
-class DeqIO[T <: Data](gen: T) extends DecoupledIO(gen) with Flipped
-{
-  /** Assert ready on this port and return the associated data bits.
-    * This is typically used when valid has been asserted by the producer side.
-    * @param b ignored
-    * @return the data for this device,
-    */
-  def deq(b: Boolean = false): T = { ready := Bool(true); bits }
-
-  /** Initialize this Bundle.
-    * NOTE: This method of initialization is still being discussed and could change in the
-    * future.
-    */
-  def init(): Unit = {
-    ready := Bool(false)
-  }
-  override def cloneType: this.type = { new DeqIO(gen).asInstanceOf[this.type]; }
+object EnqIO {
+  def apply[T<:Data](gen: T): DecoupledIO[T] = Flipped(DecoupledIO(gen))
 }
-
-/** An I/O bundle for dequeuing data with valid/ready handshaking */
-class DecoupledIOC[+T <: Data](gen: T) extends Bundle
-{
-  val ready = Bool(INPUT)
-  val valid = Bool(OUTPUT)
-  val bits  = gen.cloneType.asOutput
+object DeqIO {
+  def apply[T<:Data](gen: T): DecoupledIO[T] = DecoupledIO(gen)
 }
 
 /** An I/O Bundle for Queues
@@ -81,11 +71,11 @@ class DecoupledIOC[+T <: Data](gen: T) extends Bundle
 class QueueIO[T <: Data](gen: T, entries: Int) extends Bundle
 {
   /** I/O to enqueue data, is [[Chisel.DecoupledIO]] flipped */
-  val enq   = Decoupled(gen.cloneType).flip()
+  val enq = EnqIO(gen)
   /** I/O to enqueue data, is [[Chisel.DecoupledIO]]*/
-  val deq   = Decoupled(gen.cloneType)
+  val deq = DeqIO(gen)
   /** The current amount of data in the queue */
-  val count = UInt(OUTPUT, log2Up(entries + 1))
+  val count = Output(UInt(log2Up(entries + 1)))
 }
 
 /** A hardware module implementing a Queue
@@ -109,18 +99,18 @@ extends Module(override_reset=override_reset) {
   def this(gen: T, entries: Int, pipe: Boolean, flow: Boolean, _reset: Bool) =
     this(gen, entries, pipe, flow, Some(_reset))
   
-  val io = new QueueIO(gen, entries)
+  val io = IO(new QueueIO(gen, entries))
 
   val ram = Mem(entries, gen)
   val enq_ptr = Counter(entries)
   val deq_ptr = Counter(entries)
-  val maybe_full = Reg(init=Bool(false))
+  val maybe_full = Reg(init=false.asBool)
 
   val ptr_match = enq_ptr.value === deq_ptr.value
   val empty = ptr_match && !maybe_full
   val full = ptr_match && maybe_full
-  val do_enq = Wire(init=io.enq.fire())
-  val do_deq = Wire(init=io.deq.fire())
+  val do_enq = Wire(init=io.enq.firing)
+  val do_deq = Wire(init=io.deq.firing)
 
   when (do_enq) {
     ram(enq_ptr.value) := io.enq.bits
@@ -138,16 +128,16 @@ extends Module(override_reset=override_reset) {
   io.deq.bits := ram(deq_ptr.value)
 
   if (flow) {
-    when (io.enq.valid) { io.deq.valid := Bool(true) }
+    when (io.enq.valid) { io.deq.valid := true.asBool }
     when (empty) {
       io.deq.bits := io.enq.bits
-      do_deq := Bool(false)
-      when (io.deq.ready) { do_enq := Bool(false) }
+      do_deq := false.asBool
+      when (io.deq.ready) { do_enq := false.asBool }
     }
   }
 
   if (pipe) {
-    when (io.deq.ready) { io.enq.ready := Bool(true) }
+    when (io.deq.ready) { io.enq.ready := true.asBool }
   }
 
   val ptr_diff = enq_ptr.value - deq_ptr.value
@@ -156,7 +146,7 @@ extends Module(override_reset=override_reset) {
   } else {
     io.count := Mux(ptr_match,
                     Mux(maybe_full,
-                      UInt(entries), UInt(0)),
+                      UInt(entries), 0.asUInt),
                     Mux(deq_ptr.value > enq_ptr.value,
                       UInt(entries) + ptr_diff, ptr_diff))
   }
@@ -167,14 +157,14 @@ extends Module(override_reset=override_reset) {
   from the inputs.
 
   Example usage:
-     {{{ val q = Queue(Decoupled(UInt()), 16)
+     {{{ val q = Queue(DecoupledIO(UInt()), 16)
      q.io.enq <> producer.io.out
      consumer.io.in <> q.io.deq }}}
   */
 object Queue
 {
   def apply[T <: Data](enq: DecoupledIO[T], entries: Int = 2, pipe: Boolean = false): DecoupledIO[T]  = {
-    val q = Module(new Queue(enq.bits.cloneType, entries, pipe))
+    val q = Module(new Queue(enq.bits.newType, entries, pipe))
     q.io.enq.valid := enq.valid // not using <> so that override is allowed
     q.io.enq.bits := enq.bits
     enq.ready := q.io.enq.ready

--- a/src/main/scala/Chisel/util/Enum.scala
+++ b/src/main/scala/Chisel/util/Enum.scala
@@ -7,7 +7,8 @@ package Chisel
 
 object Enum {
   /** Returns a sequence of Bits subtypes with values from 0 until n. Helper method. */
-  private def createValues[T <: Bits](nodeType: T, n: Int): Seq[T] = (0 until n).map(x => nodeType.fromInt(x))
+  private def createValues[T <: Bits](nodeType: T, n: Int): Seq[T] =
+    (0 until n).map(x => nodeType.fromInt(x, log2Up(n)))
 
   /** create n enum values of given type */
   def apply[T <: Bits](nodeType: T, n: Int): List[T] = createValues(nodeType, n).toList

--- a/src/main/scala/Chisel/util/LFSR.scala
+++ b/src/main/scala/Chisel/util/LFSR.scala
@@ -10,10 +10,10 @@ package Chisel
   */
 object LFSR16
 {
-  def apply(increment: Bool = Bool(true)): UInt =
+  def apply(increment: Bool = true.asBool): UInt =
   {
     val width = 16
-    val lfsr = Reg(init=UInt(1, width))
+    val lfsr = Reg(init=1.asUInt(width))
     when (increment) { lfsr := Cat(lfsr(0)^lfsr(2)^lfsr(3)^lfsr(5), lfsr(width-1,1)) }
     lfsr
   }

--- a/src/main/scala/Chisel/util/Mux.scala
+++ b/src/main/scala/Chisel/util/Mux.scala
@@ -13,6 +13,7 @@ object Mux1H
   def apply[T <: Data](sel: Seq[Bool], in: Seq[T]): T =
     apply(sel zip in)
   def apply[T <: Data](in: Iterable[(Bool, T)]): T = SeqUtils.oneHotMux(in)
+
   def apply[T <: Data](sel: UInt, in: Seq[T]): T =
     apply((0 until in.size).map(sel(_)), in)
   def apply(sel: UInt, in: UInt): Bool = (sel & in).orR

--- a/src/main/scala/Chisel/util/OneHot.scala
+++ b/src/main/scala/Chisel/util/OneHot.scala
@@ -29,7 +29,7 @@ object OHToUInt {
   * @example {{{ data_out := PriorityEncoder(data_in) }}}
   */
 object PriorityEncoder {
-  def apply(in: Seq[Bool]): UInt = PriorityMux(in, (0 until in.size).map(UInt(_)))
+  def apply(in: Seq[Bool]): UInt = PriorityMux(in, (0 until in.size).map(_.asUInt))
   def apply(in: Bits): UInt = apply(in.toBools)
 }
 
@@ -39,9 +39,9 @@ object UIntToOH
 {
   def apply(in: UInt, width: Int = -1): UInt =
     if (width == -1) {
-      UInt(1) << in
+      1.asUInt << in
     } else {
-      (UInt(1) << in(log2Up(width)-1,0))(width-1,0)
+      (1.asUInt << in(log2Up(width)-1,0))(width-1,0)
     }
 }
 
@@ -51,8 +51,8 @@ object UIntToOH
 object PriorityEncoderOH
 {
   private def encode(in: Seq[Bool]): UInt = {
-    val outs = Seq.tabulate(in.size)(i => UInt(BigInt(1) << i, in.size))
-    PriorityMux(in :+ Bool(true), outs :+ UInt(0, in.size))
+    val outs = Seq.tabulate(in.size)(i => (BigInt(1) << i).asUInt(in.size))
+    PriorityMux(in :+ true.asBool, outs :+ 0.asUInt(in.size))
   }
   def apply(in: Seq[Bool]): Seq[Bool] = {
     val enc = encode(in)

--- a/src/main/scala/Chisel/util/Reg.scala
+++ b/src/main/scala/Chisel/util/Reg.scala
@@ -7,15 +7,15 @@ package Chisel
 
 object RegNext {
 
-  def apply[T <: Data](next: T): T = Reg[T](next, next, null.asInstanceOf[T])
+  def apply[T <: Data](next: T): T = Reg[T](null.asInstanceOf[T], next, null.asInstanceOf[T])
 
-  def apply[T <: Data](next: T, init: T): T = Reg[T](next, next, init)
+  def apply[T <: Data](next: T, init: T): T = Reg[T](null.asInstanceOf[T], next, init)
 
 }
 
 object RegInit {
 
-  def apply[T <: Data](init: T): T = Reg[T](init, null.asInstanceOf[T], init)
+  def apply[T <: Data](init: T): T = Reg[T](null.asInstanceOf[T], null.asInstanceOf[T], init)
 
 }
 
@@ -23,12 +23,12 @@ object RegInit {
 object RegEnable
 {
   def apply[T <: Data](updateData: T, enable: Bool): T = {
-    val r = Reg(updateData)
+    val r = Reg(updateData.newType)
     when (enable) { r := updateData }
     r
   }
   def apply[T <: Data](updateData: T, resetData: T, enable: Bool): T = {
-    val r = RegInit(resetData)
+    val r = RegInit(resetData.newType)
     when (enable) { r := updateData }
     r
   }
@@ -41,7 +41,7 @@ object ShiftRegister
   /** @param in input to delay
     * @param n number of cycles to delay
     * @param en enable the shift */
-  def apply[T <: Data](in: T, n: Int, en: Bool = Bool(true)): T =
+  def apply[T <: Data](in: T, n: Int, en: Bool = true.asBool): T =
   {
     // The order of tests reflects the expected use cases.
     if (n == 1) {

--- a/src/main/scala/Chisel/util/TransitName.scala
+++ b/src/main/scala/Chisel/util/TransitName.scala
@@ -2,14 +2,16 @@ package Chisel
 
 import internal.HasId
 
+/**
+ * The purpose of TransitName is to allow a library to 'move' a name
+ * call to a more appropriate place.
+ * For example, a library factory function may create a module and return
+ * the io. The only user-exposed field is that given IO, which can't use
+ * any name supplied by the user. This can add a hook so that the supplied
+ * name then names the Module.
+ * See Queue companion object for working example
+ */
 object TransitName {
-  // The purpose of this is to allow a library to 'move' a name call to a more
-  // appropriate place.
-  // For example, a library factory function may create a module and return
-  // the io. The only user-exposed field is that given IO, which can't use
-  // any name supplied by the user. This can add a hook so that the supplied
-  // name then names the Module.
-  // See Queue companion object for working example
   def apply[T<:HasId](from: T, to: HasId): T = {
     from.addPostnameHook((given_name: String) => {to.suggestName(given_name)})
     from

--- a/src/main/scala/Chisel/util/Valid.scala
+++ b/src/main/scala/Chisel/util/Valid.scala
@@ -5,20 +5,18 @@
 
 package Chisel
 
-/** An I/O Bundle containing data and a signal determining if it is valid */
-class ValidIO[+T <: Data](gen2: T) extends Bundle
+/** An Bundle containing data and a signal determining if it is valid */
+class Valid[+T <: Data](gen: T) extends Bundle
 {
-  val valid = Bool(OUTPUT)
-  val bits = gen2.cloneType.asOutput
+  val valid = Output(Bool())
+  val bits  = Output(gen.newType)
   def fire(dummy: Int = 0): Bool = valid
-  override def cloneType: this.type = new ValidIO(gen2).asInstanceOf[this.type]
+  override def cloneType: this.type = Valid(gen).asInstanceOf[this.type]
 }
 
-/** Adds a valid protocol to any interface. The standard used is
-  that the consumer uses the flipped interface.
-*/
+/** Adds a valid protocol to any interface */
 object Valid {
-  def apply[T <: Data](gen: T): ValidIO[T] = new ValidIO(gen)
+  def apply[T <: Data](gen: T): Valid[T] = new Valid(gen)
 }
 
 /** A hardware module that delays data coming down the pipeline
@@ -32,28 +30,28 @@ object Valid {
   */
 object Pipe
 {
-  def apply[T <: Data](enqValid: Bool, enqBits: T, latency: Int): ValidIO[T] = {
+  def apply[T <: Data](enqValid: Bool, enqBits: T, latency: Int): Valid[T] = {
     if (latency == 0) {
       val out = Wire(Valid(enqBits))
       out.valid <> enqValid
       out.bits <> enqBits
       out
     } else {
-      val v = Reg(Bool(), next=enqValid, init=Bool(false))
+      val v = Reg(Bool(), next=enqValid, init=false.asBool)
       val b = RegEnable(enqBits, enqValid)
       apply(v, b, latency-1)
     }
   }
-  def apply[T <: Data](enqValid: Bool, enqBits: T): ValidIO[T] = apply(enqValid, enqBits, 1)
-  def apply[T <: Data](enq: ValidIO[T], latency: Int = 1): ValidIO[T] = apply(enq.valid, enq.bits, latency)
+  def apply[T <: Data](enqValid: Bool, enqBits: T): Valid[T] = apply(enqValid, enqBits, 1)
+  def apply[T <: Data](enq: Valid[T], latency: Int = 1): Valid[T] = apply(enq.valid, enq.bits, latency)
 }
 
 class Pipe[T <: Data](gen: T, latency: Int = 1) extends Module
 {
-  val io = new Bundle {
-    val enq = Valid(gen).flip
-    val deq = Valid(gen)
-  }
+  val io = IO(new Bundle {
+    val enq = Input(Valid(gen))
+    val deq = Output(Valid(gen))
+  })
 
   io.deq <> Pipe(io.enq, latency)
 }

--- a/src/test/scala/chiselTests/Assert.scala
+++ b/src/test/scala/chiselTests/Assert.scala
@@ -7,7 +7,7 @@ import Chisel._
 import Chisel.testers.BasicTester
 
 class FailingAssertTester() extends BasicTester {
-  assert(Bool(false))
+  assert(false.asBool)
   // Wait to come out of reset
   val (_, done) = Counter(!reset, 4)
   when (done) {
@@ -16,7 +16,7 @@ class FailingAssertTester() extends BasicTester {
 }
 
 class SucceedingAssertTester() extends BasicTester {
-  assert(Bool(true))
+  assert(true.asBool)
   // Wait to come out of reset
   val (_, done) = Counter(!reset, 4)
   when (done) {
@@ -25,9 +25,9 @@ class SucceedingAssertTester() extends BasicTester {
 }
 
 class PipelinedResetModule extends Module {
-  val io = new Bundle { }
-  val a = Reg(init = UInt(0xbeef))
-  val b = Reg(init = UInt(0xbeef))
+  val io = IO(new Bundle { })
+  val a = Reg(init = 0xbeef.asUInt)
+  val b = Reg(init = 0xbeef.asUInt)
   assert(a === b)
 }
 

--- a/src/test/scala/chiselTests/BitwiseOps.scala
+++ b/src/test/scala/chiselTests/BitwiseOps.scala
@@ -9,12 +9,12 @@ import Chisel.testers.BasicTester
 
 class BitwiseOpsTester(w: Int, _a: Int, _b: Int) extends BasicTester {
   val mask = (1 << w) - 1
-  val a = UInt(_a, w)
-  val b = UInt(_b, w)
-  assert(~a === UInt(mask & ~_a))
-  assert((a & b) === UInt(_a & _b))
-  assert((a | b) === UInt(_a | _b))
-  assert((a ^ b) === UInt(_a ^ _b))
+  val a = _a.asUInt(w)
+  val b = _b.asUInt(w)
+  assert(~a === (mask & ~_a).asUInt)
+  assert((a & b) === (_a & _b).asUInt)
+  assert((a | b) === (_a | _b).asUInt)
+  assert((a ^ b) === (_a ^ _b).asUInt)
   stop()
 }
 

--- a/src/test/scala/chiselTests/BlackBox.scala
+++ b/src/test/scala/chiselTests/BlackBox.scala
@@ -8,36 +8,36 @@ import Chisel._
 import Chisel.testers.BasicTester
 
 class BlackBoxInverter extends BlackBox {
-  val io = new Bundle() {
-    val in = Bool(INPUT)
-    val out = Bool(OUTPUT)
-  }
+  val io = IO(new Bundle() {
+    val in = Input(Bool())
+    val out = Output(Bool())
+  })
 }
 
 class BlackBoxPassthrough extends BlackBox {
-  val io = new Bundle() {
-    val in = Bool(INPUT)
-    val out = Bool(OUTPUT)
-  }
+  val io = IO(new Bundle() {
+    val in = Input(Bool())
+    val out = Output(Bool())
+  })
 }
 
 class BlackBoxRegister extends BlackBox {
-  val io = new Bundle() {
-    val clock = Clock().asInput
-    val in = Bool(INPUT)
-    val out = Bool(OUTPUT)
-  }
+  val io = IO(new Bundle() {
+    val clock = Input(Clock())
+    val in = Input(Bool())
+    val out = Output(Bool())
+  })
 }
 
 class BlackBoxTester extends BasicTester {
   val blackBoxPos = Module(new BlackBoxInverter)
   val blackBoxNeg = Module(new BlackBoxInverter)
 
-  blackBoxPos.io.in := UInt(1)
-  blackBoxNeg.io.in := UInt(0)
+  blackBoxPos.io.in := 1.asUInt
+  blackBoxNeg.io.in := 0.asUInt
 
-  assert(blackBoxNeg.io.out === UInt(1))
-  assert(blackBoxPos.io.out === UInt(0))
+  assert(blackBoxNeg.io.out === 1.asUInt)
+  assert(blackBoxPos.io.out === 0.asUInt)
   stop()
 }
 
@@ -52,15 +52,15 @@ class MultiBlackBoxTester extends BasicTester {
   val blackBoxPassPos = Module(new BlackBoxPassthrough)
   val blackBoxPassNeg = Module(new BlackBoxPassthrough)
 
-  blackBoxInvPos.io.in := UInt(1)
-  blackBoxInvNeg.io.in := UInt(0)
-  blackBoxPassPos.io.in := UInt(1)
-  blackBoxPassNeg.io.in := UInt(0)
+  blackBoxInvPos.io.in := 1.asUInt
+  blackBoxInvNeg.io.in := 0.asUInt
+  blackBoxPassPos.io.in := 1.asUInt
+  blackBoxPassNeg.io.in := 0.asUInt
 
-  assert(blackBoxInvNeg.io.out === UInt(1))
-  assert(blackBoxInvPos.io.out === UInt(0))
-  assert(blackBoxPassNeg.io.out === UInt(0))
-  assert(blackBoxPassPos.io.out === UInt(1))
+  assert(blackBoxInvNeg.io.out === 1.asUInt)
+  assert(blackBoxInvPos.io.out === 0.asUInt)
+  assert(blackBoxPassNeg.io.out === 0.asUInt)
+  assert(blackBoxPassPos.io.out === 1.asUInt)
   stop()
 }
 
@@ -68,14 +68,14 @@ class BlackBoxWithClockTester extends BasicTester {
   val blackBox = Module(new BlackBoxRegister)
   val model = Reg(Bool())
 
-  val (cycles, end) = Counter(Bool(true), 15)
+  val (cycles, end) = Counter(true.asBool, 15)
 
   val impetus = cycles(0)
   blackBox.io.clock := clock
   blackBox.io.in := impetus
   model := impetus
 
-  when(cycles > UInt(0)) {
+  when(cycles > 0.asUInt) {
     assert(blackBox.io.out === model)
   }
   when(end) { stop() }
@@ -84,9 +84,9 @@ class BlackBoxWithClockTester extends BasicTester {
 /*
 // Must determine how to handle parameterized Verilog
 class BlackBoxConstant(value: Int) extends BlackBox {
-  val io = new Bundle() {
-    val out = UInt(width=log2Up(value)).asOutput
-  }
+  val io = IO(new Bundle() {
+    val out = Output(UInt(width=log2Up(value)))
+  })
   override val name = s"#(WIDTH=${log2Up(value)},VALUE=$value) "
 }
 
@@ -94,10 +94,10 @@ class BlackBoxWithParamsTester extends BasicTester {
   val blackBoxOne  = Module(new BlackBoxConstant(1))
   val blackBoxFour = Module(new BlackBoxConstant(4))
 
-  val (cycles, end) = Counter(Bool(true), 4)
+  val (cycles, end) = Counter(true.asBool, 4)
 
-  assert(blackBoxOne.io.out  === UInt(1))
-  assert(blackBoxFour.io.out === UInt(4))
+  assert(blackBoxOne.io.out  === 1.asUInt)
+  assert(blackBoxFour.io.out === 4.asUInt)
 
   when(end) { stop() }
 }

--- a/src/test/scala/chiselTests/BundleWire.scala
+++ b/src/test/scala/chiselTests/BundleWire.scala
@@ -12,10 +12,10 @@ class Coord extends Bundle {
 }
 
 class BundleWire(n: Int) extends Module {
-  val io = new Bundle {
-    val in   = (new Coord).asInput
-    val outs = Vec(n, new Coord).asOutput
-  }
+  val io = IO(new Bundle {
+    val in   = Input(new Coord)
+    val outs = Output(Vec(n, new Coord))
+  })
   val coords = Wire(Vec(n, new Coord))
   for (i <- 0 until n) {
     coords(i)  := io.in
@@ -25,11 +25,11 @@ class BundleWire(n: Int) extends Module {
 
 class BundleWireTester(n: Int, x: Int, y: Int) extends BasicTester {
   val dut = Module(new BundleWire(n))
-  dut.io.in.x := UInt(x)
-  dut.io.in.y := UInt(y)
+  dut.io.in.x := x.asUInt
+  dut.io.in.y := y.asUInt
   for (elt <- dut.io.outs) {
-    assert(elt.x === UInt(x))
-    assert(elt.y === UInt(y))
+    assert(elt.x === x.asUInt)
+    assert(elt.y === y.asUInt)
   }
   stop()
 }

--- a/src/test/scala/chiselTests/ComplexAssign.scala
+++ b/src/test/scala/chiselTests/ComplexAssign.scala
@@ -9,34 +9,34 @@ import Chisel.testers.BasicTester
 
 class Complex[T <: Data](val re: T, val im: T) extends Bundle {
   override def cloneType: this.type =
-    new Complex(re.cloneType, im.cloneType).asInstanceOf[this.type]
+    new Complex(re.newType, im.newType).asInstanceOf[this.type]
 }
 
 class ComplexAssign(w: Int) extends Module {
-  val io = new Bundle {
-    val e   = new Bool(INPUT)
-    val in  = new Complex(UInt(width = w), UInt(width = w)).asInput
-    val out = new Complex(UInt(width = w), UInt(width = w)).asOutput
-  }
+  val io = IO(new Bundle {
+    val e   = Input(Bool())
+    val in  = Input(new Complex(UInt(width = w), UInt(width = w)))
+    val out = Output(new Complex(UInt(width = w), UInt(width = w)))
+  })
   when (io.e) {
     val tmp = Wire(new Complex(UInt(width = w), UInt(width = w)))
     tmp := io.in
     io.out.re := tmp.re
     io.out.im := tmp.im
   } .otherwise {
-    io.out.re := UInt(0)
-    io.out.im := UInt(0)
+    io.out.re := 0.asUInt
+    io.out.im := 0.asUInt
   }
 }
 
 class ComplexAssignTester(enList: List[Boolean], re: Int, im: Int) extends BasicTester {
-  val (cnt, wrap) = Counter(Bool(true), enList.size)
+  val (cnt, wrap) = Counter(true.asBool, enList.size)
   val dut = Module(new ComplexAssign(32))
-  dut.io.in.re := UInt(re)
-  dut.io.in.im := UInt(im)
-  dut.io.e := Vec(enList.map(Bool(_)))(cnt)
-  val re_correct = dut.io.out.re === Mux(dut.io.e, dut.io.in.re, UInt(0))
-  val im_correct = dut.io.out.im === Mux(dut.io.e, dut.io.in.im, UInt(0))
+  dut.io.in.re := re.asUInt
+  dut.io.in.im := im.asUInt
+  dut.io.e := Vec(enList.map(_.asBool))(cnt)
+  val re_correct = dut.io.out.re === Mux(dut.io.e, dut.io.in.re, 0.asUInt)
+  val im_correct = dut.io.out.im === Mux(dut.io.e, dut.io.in.im, 0.asUInt)
   assert(re_correct && im_correct)
   when(wrap) {
     stop()

--- a/src/test/scala/chiselTests/Counter.scala
+++ b/src/test/scala/chiselTests/Counter.scala
@@ -8,29 +8,29 @@ import Chisel.testers.BasicTester
 
 class CountTester(max: Int) extends BasicTester {
   val cnt = Counter(max)
-  when(Bool(true)) { cnt.inc() }
-  when(cnt.value === UInt(max-1)) {
+  when(true.asBool) { cnt.inc() }
+  when(cnt.value === (max-1).asUInt) {
     stop()
   }
 }
 
 class EnableTester(seed: Int) extends BasicTester {
-  val ens = Reg(init = UInt(seed))
+  val ens = Reg(init = seed.asUInt)
   ens := ens >> 1
 
   val (cntEnVal, _) = Counter(ens(0), 32)
-  val (_, done) = Counter(Bool(true), 33)
+  val (_, done) = Counter(true.asBool, 33)
 
   when(done) {
-    assert(cntEnVal === UInt(popCount(seed)))
+    assert(cntEnVal === popCount(seed).asUInt)
     stop()
   }
 }
 
 class WrapTester(max: Int) extends BasicTester {
-  val (cnt, wrap) = Counter(Bool(true), max)
+  val (cnt, wrap) = Counter(true.asBool, max)
   when(wrap) {
-    assert(cnt === UInt(max - 1))
+    assert(cnt === (max - 1).asUInt)
     stop()
   }
 }

--- a/src/test/scala/chiselTests/Decoder.scala
+++ b/src/test/scala/chiselTests/Decoder.scala
@@ -8,20 +8,20 @@ import org.scalacheck._
 import Chisel.testers.BasicTester
 
 class Decoder(bitpats: List[String]) extends Module {
-  val io = new Bundle {
-    val inst  = UInt(INPUT, 32)
-    val matched = Bool(OUTPUT)
-  }
+  val io = IO(new Bundle {
+    val inst  = Input(UInt(32))
+    val matched = Output(Bool())
+  })
   io.matched := Vec(bitpats.map(BitPat(_) === io.inst)).reduce(_||_)
 }
 
 class DecoderTester(pairs: List[(String, String)]) extends BasicTester {
   val (insts, bitpats) = pairs.unzip
-  val (cnt, wrap) = Counter(Bool(true), pairs.size)
+  val (cnt, wrap) = Counter(true.asBool, pairs.size)
   val dut = Module(new Decoder(bitpats))
-  dut.io.inst := Vec(insts.map(UInt(_)))(cnt)
+  dut.io.inst := Vec(insts.map(_.asUInt))(cnt)
   when(!dut.io.matched) {
-    assert(cnt === UInt(0))
+    assert(cnt === 0.asUInt)
     stop()
   }
   when(wrap) {

--- a/src/test/scala/chiselTests/DeqIOSpec.scala
+++ b/src/test/scala/chiselTests/DeqIOSpec.scala
@@ -15,17 +15,17 @@ class UsesDeqIOInfo extends Bundle {
 }
 
 class UsesDeqIO extends Module {
-  val io = new Bundle {
-    val in = new DeqIO(new UsesDeqIOInfo)
-    val out = new EnqIO(new UsesDeqIOInfo)
-  }
+  val io = IO(new Bundle {
+    val in = DeqIO(new UsesDeqIOInfo)
+    val out = EnqIO(new UsesDeqIOInfo)
+  })
 }
 
 class DeqIOSpec extends ChiselFlatSpec {
   runTester {
     new BasicTester {
       val dut = new UsesDeqIO
-
+/*
       "DeqIO" should "set the direction of it's parameter to INPUT" in {
         assert(dut.io.in.bits.info_data.dir === INPUT)
       }
@@ -55,6 +55,7 @@ class DeqIOSpec extends ChiselFlatSpec {
         assert(dut.io.out.ready.dir == out_clone.ready.dir)
         assert(dut.io.out.valid.dir == out_clone.valid.dir)
       }
+      */
     }
   }
 }

--- a/src/test/scala/chiselTests/Direction.scala
+++ b/src/test/scala/chiselTests/Direction.scala
@@ -8,18 +8,18 @@ import org.scalatest.prop._
 import Chisel.testers.BasicTester
 
 class DirectionHaver extends Module {
-  val io = new Bundle {
-    val in = UInt(INPUT, 32)
-    val out = UInt(OUTPUT, 32)
-  }
+  val io = IO(new Bundle {
+    val in = Input(UInt(32))
+    val out = Output(UInt(32))
+  })
 }
 
 class GoodDirection extends DirectionHaver {
-  io.out := UInt(0)
+  io.out := 0.asUInt
 }
 
 class BadDirection extends DirectionHaver {
-  io.in := UInt(0)
+  io.in := 0.asUInt
 }
 
 class DirectionSpec extends ChiselPropSpec {
@@ -31,7 +31,14 @@ class DirectionSpec extends ChiselPropSpec {
   }
 
   property("Inputs should not be assignable") {
-    elaborate(new BadDirection)
+    var excepts: Boolean = false
+    try elaborate(new BadDirection)
+    catch {
+      case e: Exception => {excepts = true}
+      // Should except so this is okay
+      // Ideally, would throw and catch more precise exception
+    }
+    assert(excepts, "Bad connection should have thrown exception!")
   }
 
 }

--- a/src/test/scala/chiselTests/EnableShiftRegister.scala
+++ b/src/test/scala/chiselTests/EnableShiftRegister.scala
@@ -5,15 +5,15 @@ import Chisel._
 import Chisel.testers.BasicTester
 
 class EnableShiftRegister extends Module {
-  val io = new Bundle {
-    val in    = UInt(INPUT, 4)
-    val shift = Bool(INPUT)
-    val out   = UInt(OUTPUT, 4)
-  }
-  val r0 = Reg(init = UInt(0, 4))
-  val r1 = Reg(init = UInt(0, 4))
-  val r2 = Reg(init = UInt(0, 4))
-  val r3 = Reg(init = UInt(0, 4))
+  val io = IO(new Bundle {
+    val in    = Input(UInt(4))
+    val shift = Input(Bool())
+    val out   = Output(UInt(4))
+  })
+  val r0 = Reg(init = 0.asUInt(4))
+  val r1 = Reg(init = 0.asUInt(4))
+  val r2 = Reg(init = 0.asUInt(4))
+  val r3 = Reg(init = 0.asUInt(4))
   when(io.shift) {
     r0 := io.in
     r1 := r0

--- a/src/test/scala/chiselTests/GCD.scala
+++ b/src/test/scala/chiselTests/GCD.scala
@@ -8,31 +8,31 @@ import org.scalatest._
 import org.scalatest.prop._
 
 class GCD extends Module {
-  val io = new Bundle {
-    val a  = UInt(INPUT, 32)
-    val b  = UInt(INPUT, 32)
-    val e  = Bool(INPUT)
-    val z  = UInt(OUTPUT, 32)
-    val v  = Bool(OUTPUT)
-  }
+  val io = IO(new Bundle {
+    val a  = Input(UInt(32))
+    val b  = Input(UInt(32))
+    val e  = Input(Bool())
+    val z  = Output(UInt(32))
+    val v  = Output(Bool())
+  })
   val x = Reg(UInt(width = 32))
   val y = Reg(UInt(width = 32))
   when (x > y)   { x := x -% y }
   .otherwise     { y := y -% x }
   when (io.e) { x := io.a; y := io.b }
   io.z := x
-  io.v := y === UInt(0)
+  io.v := y === 0.asUInt
 }
 
 class GCDTester(a: Int, b: Int, z: Int) extends BasicTester {
   val dut = Module(new GCD)
-  val first = Reg(init=Bool(true))
-  dut.io.a := UInt(a)
-  dut.io.b := UInt(b)
+  val first = Reg(init=true.asBool)
+  dut.io.a := a.asUInt
+  dut.io.b := b.asUInt
   dut.io.e := first
-  when(first) { first := Bool(false) }
+  when(first) { first := false.asBool }
   when(dut.io.v) {
-    assert(dut.io.z === UInt(z))
+    assert(dut.io.z === z.asUInt)
     stop()
   }
 }

--- a/src/test/scala/chiselTests/LFSR16.scala
+++ b/src/test/scala/chiselTests/LFSR16.scala
@@ -5,11 +5,11 @@ import Chisel._
 import Chisel.testers.BasicTester
 
 class LFSR16 extends Module {
-  val io = new Bundle {
-    val inc = Bool(INPUT)
-    val out = UInt(OUTPUT, 16)
-  }
-  val res = Reg(init = UInt(1, 16))
+  val io = IO(new Bundle {
+    val inc = Input(Bool())
+    val out = Output(UInt(16))
+  })
+  val res = Reg(init = 1.asUInt(16))
   when (io.inc) {
     val nxt_res = Cat(res(0)^res(2)^res(3)^res(5), res(15,1))
     res := nxt_res

--- a/src/test/scala/chiselTests/MemorySearch.scala
+++ b/src/test/scala/chiselTests/MemorySearch.scala
@@ -5,22 +5,22 @@ import Chisel._
 import Chisel.testers.BasicTester
 
 class MemorySearch extends Module {
-  val io = new Bundle {
-    val target  = UInt(INPUT,  4)
-    val en      = Bool(INPUT)
-    val done    = Bool(OUTPUT)
-    val address = UInt(OUTPUT, 3)
-  }
+  val io = IO(new Bundle {
+    val target  = Input(UInt(4))
+    val en      = Input(Bool())
+    val done    = Output(Bool())
+    val address = Output(UInt(3))
+  })
   val vals  = Array(0, 4, 15, 14, 2, 5, 13)
-  val index = Reg(init = UInt(0, width = 3))
-  val elts  = Vec(vals.map(UInt(_,4)))
+  val index = Reg(init = 0.asUInt(3))
+  val elts  = Vec(vals.map(_.asUInt(4)))
   // val elts  = Mem(UInt(width = 32), 8) TODO ????
   val elt  = elts(index)
-  val end  = !io.en && ((elt === io.target) || (index === UInt(7)))
+  val end  = !io.en && ((elt === io.target) || (index === 7.asUInt))
   when (io.en) {
-    index := UInt(0)
+    index := 0.asUInt
   } .elsewhen (!end) {
-    index := index +% UInt(1)
+    index := index +% 1.asUInt
   }
   io.done    := end
   io.address := index

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -4,20 +4,20 @@ package chiselTests
 import Chisel._
 
 class SimpleIO extends Bundle {
-  val in  = UInt(INPUT,  32)
-  val out = UInt(OUTPUT, 32)
+  val in  = Input(UInt(32))
+  val out = Output(UInt(32))
 }
 
 class PlusOne extends Module {
-  val io = new SimpleIO
-  io.out := io.in + UInt(1)
+  val io = IO(new SimpleIO)
+  io.out := io.in + 1.asUInt
 }
 
 class ModuleVec(val n: Int) extends Module {
-  val io = new Bundle {
-    val ins  = Vec(n, UInt(INPUT,  32))
-    val outs = Vec(n, UInt(OUTPUT, 32))
-  }
+  val io = IO(new Bundle {
+    val ins  = Input(Vec(n, UInt(32)))
+    val outs = Output(Vec(n, UInt(32)))
+  })
   val pluses = Vec.fill(n){ Module(new PlusOne).io }
   for (i <- 0 until n) {
     pluses(i).in := io.ins(i)
@@ -39,8 +39,8 @@ class ModuleVecTester(c: ModuleVec) extends Tester(c) {
 */
 
 class ModuleWire extends Module {
-  val io = new SimpleIO
-  val inc = Wire(Module(new PlusOne).io)
+  val io = IO(new SimpleIO)
+  val inc = Wire(Module(new PlusOne).io.newType)
   inc.in := io.in
   io.out := inc.out
 }
@@ -57,10 +57,10 @@ class ModuleWireTester(c: ModuleWire) extends Tester(c) {
 */
 
 class ModuleWhen extends Module {
-  val io = new Bundle {
+  val io = IO(new Bundle {
     val s = new SimpleIO
     val en = Bool()
-  }
+  })
   when(io.en) {
     val inc = Module(new PlusOne).io
     inc.in := io.s.in

--- a/src/test/scala/chiselTests/MulLookup.scala
+++ b/src/test/scala/chiselTests/MulLookup.scala
@@ -8,25 +8,25 @@ import org.scalatest.prop._
 import Chisel.testers.BasicTester
 
 class MulLookup(val w: Int) extends Module {
-  val io = new Bundle {
-    val x   = UInt(INPUT,  w)
-    val y   = UInt(INPUT,  w)
-    val z   = UInt(OUTPUT, 2 * w)
-  }
+  val io = IO(new Bundle {
+    val x   = Input(UInt(w))
+    val y   = Input(UInt(w))
+    val z   = Output(UInt(2 * w))
+  })
   val tbl = Vec(
     for {
       i <- 0 until 1 << w
       j <- 0 until 1 << w
-    } yield UInt(i * j, 2 * w)
+    } yield (i * j).asUInt(2 * w)
   )
   io.z := tbl(((io.x << w) | io.y))
 }
 
 class MulLookupTester(w: Int, x: Int, y: Int) extends BasicTester {
   val dut = Module(new MulLookup(w))
-  dut.io.x := UInt(x)
-  dut.io.y := UInt(y)
-  assert(dut.io.z === UInt(x * y))
+  dut.io.x := x.asUInt
+  dut.io.y := y.asUInt
+  assert(dut.io.z === (x * y).asUInt)
   stop()
 }
 

--- a/src/test/scala/chiselTests/OptionBundle.scala
+++ b/src/test/scala/chiselTests/OptionBundle.scala
@@ -8,39 +8,39 @@ import Chisel.testers.BasicTester
 
 class OptionBundle(hasIn: Boolean) extends Bundle {
   val in = if (hasIn) {
-    Some(Bool(INPUT))
+    Some(Input(Bool()))
   } else {
     None
   }
-  val out = Bool(OUTPUT)
+  val out = Output(Bool())
 }
 
 class OptionBundleModule(hasIn: Boolean) extends Module {
-  val io = new OptionBundle(hasIn)
+  val io = IO(new OptionBundle(hasIn))
   if (hasIn) {
     io.out := io.in.get
   } else {
-    io.out := Bool(false)
+    io.out := false.asBool
   }
 }
 
 class SomeOptionBundleTester(expected: Boolean) extends BasicTester {
   val mod = Module(new OptionBundleModule(true))
-  mod.io.in.get := Bool(expected)
-  assert(mod.io.out === Bool(expected))
+  mod.io.in.get := expected.asBool
+  assert(mod.io.out === expected.asBool)
   stop()
 }
 
 class NoneOptionBundleTester() extends BasicTester {
   val mod = Module(new OptionBundleModule(false))
-  assert(mod.io.out === Bool(false))
+  assert(mod.io.out === false.asBool)
   stop()
 }
 
 class InvalidOptionBundleTester() extends BasicTester {
   val mod = Module(new OptionBundleModule(false))
-  mod.io.in.get := Bool(true)
-  assert(Bool(false))
+  mod.io.in.get := true.asBool
+  assert(false.asBool)
   stop()
 }
 

--- a/src/test/scala/chiselTests/Padding.scala
+++ b/src/test/scala/chiselTests/Padding.scala
@@ -4,11 +4,11 @@ package chiselTests
 import Chisel._
 
 class Padder extends Module {
-  val io = new Bundle {
-    val a   = Bits(INPUT,  4)
-    val asp = SInt(OUTPUT, 8)
-    val aup = UInt(OUTPUT, 8)
-  }
+  val io = IO(new Bundle {
+    val a   = Input(UInt(4))
+    val asp = Output(SInt(8))
+    val aup = Output(UInt(8))
+  })
   io.asp := io.a.asSInt
   io.aup := io.a.asUInt
 }

--- a/src/test/scala/chiselTests/ParameterizedModule.scala
+++ b/src/test/scala/chiselTests/ParameterizedModule.scala
@@ -7,10 +7,10 @@ import Chisel._
 import Chisel.testers.BasicTester
 
 class ParameterizedModule(invert: Boolean) extends Module {
-  val io = new Bundle {
-    val in = new Bool(INPUT)
-    val out = new Bool(OUTPUT)
-  }
+  val io = IO(new Bundle {
+    val in  = Input(Bool())
+    val out = Output(Bool())
+  })
   if (invert) {
     io.out := !io.in
   } else {
@@ -26,10 +26,10 @@ class ParameterizedModuleTester() extends BasicTester {
   val invert = Module(new ParameterizedModule(true))
   val noninvert = Module(new ParameterizedModule(false))
 
-  invert.io.in := Bool(true)
-  noninvert.io.in := Bool(true)
-  assert(invert.io.out === Bool(false))
-  assert(noninvert.io.out === Bool(true))
+  invert.io.in := true.asBool
+  noninvert.io.in := true.asBool
+  assert(invert.io.out === false.asBool)
+  assert(noninvert.io.out === true.asBool)
 
   stop()
 }

--- a/src/test/scala/chiselTests/Printf.scala
+++ b/src/test/scala/chiselTests/Printf.scala
@@ -7,19 +7,19 @@ import Chisel._
 import Chisel.testers.BasicTester
 
 class SinglePrintfTester() extends BasicTester {
-  val x = UInt(254)
+  val x = 254.asUInt
   printf("x=%x", x)
   stop()
 }
 
 class ASCIIPrintfTester() extends BasicTester {
-  printf((0x20 to 0x7e).map(_ toChar).mkString.replace("%", "%%"))
+  printf((0x20 to 0x7e).map(_.toChar).mkString.replace("%", "%%"))
   stop()
 }
 
 class MultiPrintfTester() extends BasicTester {
-  val x = UInt(254)
-  val y = UInt(255)
+  val x = 254.asUInt
+  val y = 255.asUInt
   printf("x=%x y=%x", x, y)
   stop()
 }

--- a/src/test/scala/chiselTests/Reg.scala
+++ b/src/test/scala/chiselTests/Reg.scala
@@ -15,28 +15,28 @@ class RegSpec extends ChiselFlatSpec {
 
   "A Reg" should "be of the same type and width as outType, if specified" in {
     class RegOutTypeWidthTester extends BasicTester {
-      val reg = Reg(t=UInt(width=2), next=UInt(width=3), init=UInt(20))
-      reg.width.get should be (2)
+      val reg = Reg(t=UInt(width=2), next=Wire(UInt(width=3)), init=20.asUInt)
+      reg.getWidth should be (2)
     }
     elaborate{ new RegOutTypeWidthTester }
   }
 
   "A Reg" should "be of unknown width if outType is not specified and width is not forced" in {
     class RegUnknownWidthTester extends BasicTester {
-      val reg1 = Reg(next=UInt(width=3), init=UInt(20))
-      reg1.width.known should be (false)
-      val reg2 = Reg(init=UInt(20))
-      reg2.width.known should be (false)
-      val reg3 = Reg(next=UInt(width=3), init=UInt(width=5))
-      reg3.width.known should be (false)
+      val reg1 = Reg(next=Wire(UInt(width=3)), init=20.asUInt)
+      DataMirror.widthOf(reg1).known should be (false)
+      val reg2 = Reg(init=20.asUInt)
+      DataMirror.widthOf(reg2).known should be (false)
+      val reg3 = Reg(next=Wire(UInt(width=3)), init=5.asUInt)
+      DataMirror.widthOf(reg3).known should be (false)
     }
     elaborate { new RegUnknownWidthTester }
   }
 
   "A Reg" should "be of width of init if outType and next are missing and init is a literal of forced width" in {
     class RegForcedWidthTester extends BasicTester {
-      val reg2 = Reg(init=UInt(20, width=7))
-      reg2.width.get should be (7)
+      val reg2 = Reg(init=20.asUInt(7))
+      reg2.getWidth should be (7)
     }
     elaborate{ new RegForcedWidthTester }
   }

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -5,24 +5,24 @@ import Chisel._
 import Chisel.testers.BasicTester
 
 class SIntOps extends Module {
-  val io = new Bundle {
-    val a = SInt(INPUT, 16)
-    val b = SInt(INPUT, 16)
-    val addout = SInt(OUTPUT, 16)
-    val subout = SInt(OUTPUT, 16)
-    val timesout = SInt(OUTPUT, 16)
-    val divout = SInt(OUTPUT, 16)
-    val modout = SInt(OUTPUT, 16)
-    val lshiftout = SInt(OUTPUT, 16)
-    val rshiftout = SInt(OUTPUT, 16)
-    val lessout = Bool(OUTPUT)
-    val greatout = Bool(OUTPUT)
-    val eqout = Bool(OUTPUT)
-    val noteqout = Bool(OUTPUT)
-    val lesseqout = Bool(OUTPUT)
-    val greateqout = Bool(OUTPUT)
-    val negout = SInt(OUTPUT, 16)
-  }
+  val io = IO(new Bundle {
+    val a = Input(SInt(16))
+    val b = Input(SInt(16))
+    val addout = Output(SInt(16))
+    val subout = Output(SInt(16))
+    val timesout = Output(SInt(16))
+    val divout = Output(SInt(16))
+    val modout = Output(SInt(16))
+    val lshiftout = Output(SInt(16))
+    val rshiftout = Output(SInt(16))
+    val lessout = Output(Bool())
+    val greatout = Output(Bool())
+    val eqout = Output(Bool())
+    val noteqout = Output(Bool())
+    val lesseqout = Output(Bool())
+    val greateqout = Output(Bool())
+    val negout = Output(SInt(16))
+  })
 
   val a = io.a
   val b = io.b
@@ -31,9 +31,9 @@ class SIntOps extends Module {
   io.subout := a -% b
   // TODO:
   //io.timesout := (a * b)(15, 0)
-  //io.divout := a / Mux(b === SInt(0), SInt(1), b)
+  //io.divout := a / Mux(b === 0.asSInt, 1.asSInt, b)
   //io.divout := (a / b)(15, 0)
-  //io.modout := SInt(0)
+  //io.modout := 0.asSInt
   //io.lshiftout := (a << 12)(15, 0) //  (a << ub(3, 0))(15, 0).toSInt
   io.rshiftout := (a >> 8) // (a >> ub).toSInt
   io.lessout := a < b
@@ -43,7 +43,7 @@ class SIntOps extends Module {
   io.lesseqout := a <= b
   io.greateqout := a >= b
   // io.negout := -a(15, 0).toSInt
-  io.negout := (SInt(0) -% a)
+  io.negout := (0.asSInt -% a)
 }
 
 /*

--- a/src/test/scala/chiselTests/Stack.scala
+++ b/src/test/scala/chiselTests/Stack.scala
@@ -5,27 +5,27 @@ import scala.collection.mutable.Stack
 import Chisel._
 
 class ChiselStack(val depth: Int) extends Module {
-  val io = new Bundle {
-    val push    = Bool(INPUT)
-    val pop     = Bool(INPUT)
-    val en      = Bool(INPUT)
-    val dataIn  = UInt(INPUT,  32)
-    val dataOut = UInt(OUTPUT, 32)
-  }
+  val io = IO(new Bundle {
+    val push    = Input(Bool())
+    val pop     = Input(Bool())
+    val en      = Input(Bool())
+    val dataIn  = Input(UInt(32))
+    val dataOut = Output(UInt(32))
+  })
 
-  val stack_mem = Mem(depth, UInt(width = 32))
-  val sp        = Reg(init = UInt(0, width = log2Up(depth + 1)))
-  val out       = Reg(init = UInt(0, width = 32))
+  val stack_mem = Mem(depth, UInt(32))
+  val sp        = Reg(init = 0.asUInt(log2Up(depth + 1)))
+  val out       = Reg(init = 0.asUInt(32))
 
   when (io.en) {
-    when(io.push && (sp < UInt(depth))) {
+    when(io.push && (sp < depth.asUInt)) {
       stack_mem(sp) := io.dataIn
-      sp := sp +% UInt(1)
-    } .elsewhen(io.pop && (sp > UInt(0))) {
-      sp := sp -% UInt(1)
+      sp := sp +% 1.asUInt
+    } .elsewhen(io.pop && (sp > 0.asUInt)) {
+      sp := sp -% 1.asUInt
     }
-    when (sp > UInt(0)) {
-      out := stack_mem(sp -% UInt(1))
+    when (sp > 0.asUInt) {
+      out := stack_mem(sp -% 1.asUInt)
     }
   }
   io.dataOut := out

--- a/src/test/scala/chiselTests/Tbl.scala
+++ b/src/test/scala/chiselTests/Tbl.scala
@@ -8,13 +8,13 @@ import org.scalatest.prop._
 import Chisel.testers.BasicTester
 
 class Tbl(w: Int, n: Int) extends Module {
-  val io = new Bundle {
-    val wi  = UInt(INPUT, log2Up(n))
-    val ri  = UInt(INPUT, log2Up(n))
-    val we  = Bool(INPUT)
-    val  d  = UInt(INPUT, w)
-    val  o  = UInt(OUTPUT, w)
-  }
+  val io = IO(new Bundle {
+    val wi  = Input(UInt(log2Up(n)))
+    val ri  = Input(UInt(log2Up(n)))
+    val we  = Input(Bool())
+    val  d  = Input(UInt(w))
+    val  o  = Output(UInt(w))
+  })
   val m = Mem(n, UInt(width = w))
   io.o := m(io.ri)
   when (io.we) {
@@ -26,17 +26,17 @@ class Tbl(w: Int, n: Int) extends Module {
 }
 
 class TblTester(w: Int, n: Int, idxs: List[Int], values: List[Int]) extends BasicTester {
-  val (cnt, wrap) = Counter(Bool(true), idxs.size)
+  val (cnt, wrap) = Counter(true.asBool, idxs.size)
   val dut = Module(new Tbl(w, n))
-  val vvalues = Vec(values.map(UInt(_)))
-  val vidxs = Vec(idxs.map(UInt(_)))
-  val prev_idx = vidxs(cnt - UInt(1))
-  val prev_value = vvalues(cnt - UInt(1))
+  val vvalues = Vec(values.map(_.asUInt))
+  val vidxs = Vec(idxs.map(_.asUInt))
+  val prev_idx = vidxs(cnt - 1.asUInt)
+  val prev_value = vvalues(cnt - 1.asUInt)
   dut.io.wi := vidxs(cnt)
   dut.io.ri := prev_idx
-  dut.io.we := Bool(true) //TODO enSequence
+  dut.io.we := true.asBool //TODO enSequence
   dut.io.d := vvalues(cnt)
-  when (cnt > UInt(0)) {
+  when (cnt > 0.asUInt) {
     when (prev_idx === vidxs(cnt)) {
       assert(dut.io.o === vvalues(cnt))
     } .otherwise {

--- a/src/test/scala/chiselTests/TesterDriverSpec.scala
+++ b/src/test/scala/chiselTests/TesterDriverSpec.scala
@@ -19,17 +19,17 @@ class FinishTester extends BasicTester {
     stop()
   }
 
-  val test_wire = Wire(UInt(1, width = test_wire_width))
+  val test_wire = Wire(init=1.asUInt(test_wire_width))
 
   // though we just set test_wire to 1, the assert below will pass because
   // the finish will change its value
-  assert(test_wire === UInt(test_wire_override_value))
+  assert(test_wire === test_wire_override_value.asUInt)
 
   /** In finish we use last connect semantics to alter the test_wire in the circuit
     * with a new value
     */
   override def finish(): Unit = {
-    test_wire := UInt(test_wire_override_value)
+    test_wire := test_wire_override_value.asUInt
   }
 }
 

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -6,23 +6,23 @@ import org.scalatest._
 import Chisel.testers.BasicTester
 
 class UIntOps extends Module {
-  val io = new Bundle {
-    val a = UInt(INPUT, 16)
-    val b = UInt(INPUT, 16)
-    val addout = UInt(OUTPUT, 16)
-    val subout = UInt(OUTPUT, 16)
-    val timesout = UInt(OUTPUT, 16)
-    val divout = UInt(OUTPUT, 16)
-    val modout = UInt(OUTPUT, 16)
-    val lshiftout = UInt(OUTPUT, 16)
-    val rshiftout = UInt(OUTPUT, 16)
-    val lessout = Bool(OUTPUT)
-    val greatout = Bool(OUTPUT)
-    val eqout = Bool(OUTPUT)
-    val noteqout = Bool(OUTPUT)
-    val lesseqout = Bool(OUTPUT)
-    val greateqout = Bool(OUTPUT)
-  }
+  val io = IO(new Bundle {
+    val a = Input(UInt(16))
+    val b = Input(UInt(16))
+    val addout = Output(UInt(16))
+    val subout = Output(UInt(16))
+    val timesout = Output(UInt(16))
+    val divout = Output(UInt(16))
+    val modout = Output(UInt(16))
+    val lshiftout = Output(UInt(16))
+    val rshiftout = Output(UInt(16))
+    val lessout = Output(Bool())
+    val greatout = Output(Bool())
+    val eqout = Output(Bool())
+    val noteqout = Output(Bool())
+    val lesseqout = Output(Bool())
+    val greateqout = Output(Bool())
+  })
 
   val a = io.a
   val b = io.b
@@ -30,10 +30,10 @@ class UIntOps extends Module {
   io.addout := a +% b
   io.subout := a -% b
   io.timesout := (a * b)(15, 0)
-  io.divout := a / Mux(b === UInt(0), UInt(1), b)
+  io.divout := a / Mux(b === 0.asUInt, 1.asUInt, b)
   // io.modout := a % b
   // TODO:
-  io.modout := UInt(0)
+  io.modout := 0.asUInt
   io.lshiftout := (a << b(3, 0))(15, 0)
   io.rshiftout := a >> b
   io.lessout := a < b
@@ -76,18 +76,18 @@ class UIntOpsTester(c: UIntOps) extends Tester(c) {
 */
 
 class GoodBoolConversion extends Module {
-  val io = new Bundle {
-    val u = UInt(1, width = 1).asInput
-    val b = Bool(OUTPUT)
-  }
+  val io = IO(new Bundle {
+    val u = Input(UInt(1))
+    val b = Output(Bool())
+  })
   io.b := io.u.toBool
 }
 
 class BadBoolConversion extends Module {
-  val io = new Bundle {
-    val u = UInt(1, width = 5).asInput
-    val b = Bool(OUTPUT)
-  }
+  val io = IO(new Bundle {
+    val u = Input(UInt(width = 5))
+    val b = Output(Bool())
+  })
   io.b := io.u.toBool
 }
 

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -8,17 +8,17 @@ import org.scalatest.prop._
 import Chisel.testers.BasicTester
 
 class ValueTester(w: Int, values: List[Int]) extends BasicTester {
-  val v = Vec(values.map(UInt(_, width = w))) // TODO: does this need a Wire? Why no error?
+  val v = Vec(values.map(_.asUInt(w))) // TODO: does this need a Wire? Why no error?
   for ((a,b) <- v.zip(values)) {
-    assert(a === UInt(b))
+    assert(a === b.asUInt)
   }
   stop()
 }
 
 class TabulateTester(n: Int) extends BasicTester {
-  val v = Vec(Range(0, n).map(i => UInt(i * 2)))
-  val x = Vec(Array.tabulate(n){ i => UInt(i * 2) })
-  val u = Vec.tabulate(n)(i => UInt(i*2))
+  val v = Vec(Range(0, n).map(i => (i * 2).asUInt))
+  val x = Vec(Array.tabulate(n){ i => (i * 2).asUInt })
+  val u = Vec.tabulate(n)(i => (i*2).asUInt)
 
   assert(v.toBits === x.toBits)
   assert(v.toBits === u.toBits)
@@ -28,12 +28,12 @@ class TabulateTester(n: Int) extends BasicTester {
 }
 
 class ShiftRegisterTester(n: Int) extends BasicTester {
-  val (cnt, wrap) = Counter(Bool(true), n*2)
+  val (cnt, wrap) = Counter(true.asBool, n*2)
   val shifter = Reg(Vec(n, UInt(width = log2Up(n))))
   (shifter, shifter drop 1).zipped.foreach(_ := _)
   shifter(n-1) := cnt
-  when (cnt >= UInt(n)) {
-    val expected = cnt - UInt(n)
+  when (cnt >= n.asUInt) {
+    val expected = cnt - n.asUInt
     assert(shifter(0) === expected)
   }
   when (wrap) {

--- a/src/test/scala/chiselTests/VectorPacketIO.scala
+++ b/src/test/scala/chiselTests/VectorPacketIO.scala
@@ -27,8 +27,8 @@ class Packet extends Bundle {
   * The problem does not occur if the Vec is taken out
   */
 class VectorPacketIO(n: Int) extends Bundle {
-  val ins  = Vec(n, new DeqIO(new Packet()))
-  val outs = Vec(n, new EnqIO(new Packet()))
+  val ins  = Vec(n, DeqIO(new Packet()))
+  val outs = Vec(n, EnqIO(new Packet()))
 }
 
 /**
@@ -37,10 +37,11 @@ class VectorPacketIO(n: Int) extends Bundle {
   */
 class BrokenVectorPacketModule extends Module {
   val n  = 4
-  val io = new VectorPacketIO(n)
+  val io = IO(new VectorPacketIO(n))
 
   /* the following method of initializing the circuit may change in the future */
-  io.outs.foreach(_.init())
+  io.ins.foreach(_.noenq())
+  io.outs.foreach(_.nodeq())
 }
 
 class VectorPacketIOUnitTester extends BasicTester {

--- a/src/test/scala/chiselTests/VendingMachine.scala
+++ b/src/test/scala/chiselTests/VendingMachine.scala
@@ -4,11 +4,12 @@ package chiselTests
 import Chisel._
 
 class VendingMachine extends Module {
-  val io = new Bundle {
-    val nickel = Bool(dir = INPUT)
-    val dime   = Bool(dir = INPUT)
-    val valid  = Bool(dir = OUTPUT) }
-  val c = UInt(5, width = 3)
+  val io = IO(new Bundle {
+    val nickel = Input(Bool())
+    val dime   = Input(Bool())
+    val valid  = Output(Bool())
+  })
+  val c = 5.asUInt(3)
   val sIdle :: s5 :: s10 :: s15 :: sOk :: Nil = Enum(UInt(), 5)
   val state = Reg(init = sIdle)
   when (state === sIdle) {

--- a/src/test/scala/chiselTests/When.scala
+++ b/src/test/scala/chiselTests/When.scala
@@ -8,44 +8,44 @@ import Chisel.testers.BasicTester
 
 class WhenTester() extends BasicTester {
   val cnt = Counter(4)
-  when(Bool(true)) { cnt.inc() }
+  when(true.asBool) { cnt.inc() }
 
   val out = Wire(UInt(width=3))
-  when(cnt.value === UInt(0)) {
-    out := UInt(1)
-  } .elsewhen (cnt.value === UInt(1)) {
-    out := UInt(2)
-  } .elsewhen (cnt.value === UInt(2)) {
-    out := UInt(3)
+  when(cnt.value === 0.asUInt) {
+    out := 1.asUInt
+  } .elsewhen (cnt.value === 1.asUInt) {
+    out := 2.asUInt
+  } .elsewhen (cnt.value === 2.asUInt) {
+    out := 3.asUInt
   } .otherwise {
-    out := UInt(0)
+    out := 0.asUInt
   }
 
-  assert(out === cnt.value + UInt(1))
+  assert(out === cnt.value + 1.asUInt)
 
-  when(cnt.value === UInt(3)) {
+  when(cnt.value === 3.asUInt) {
     stop()
   }
 }
 
 class OverlappedWhenTester() extends BasicTester {
   val cnt = Counter(4)
-  when(Bool(true)) { cnt.inc() }
+  when(true.asBool) { cnt.inc() }
 
   val out = Wire(UInt(width=3))
-  when(cnt.value <= UInt(0)) {
-    out := UInt(1)
-  } .elsewhen (cnt.value <= UInt(1)) {
-    out := UInt(2)
-  } .elsewhen (cnt.value <= UInt(2)) {
-    out := UInt(3)
+  when(cnt.value <= 0.asUInt) {
+    out := 1.asUInt
+  } .elsewhen (cnt.value <= 1.asUInt) {
+    out := 2.asUInt
+  } .elsewhen (cnt.value <= 2.asUInt) {
+    out := 3.asUInt
   } .otherwise {
-    out := UInt(0)
+    out := 0.asUInt
   }
 
-  assert(out === cnt.value + UInt(1))
+  assert(out === cnt.value + 1.asUInt)
 
-  when(cnt.value === UInt(3)) {
+  when(cnt.value === 3.asUInt) {
     stop()
   }
 }


### PR DESCRIPTION
First set of changes:
Require io be wrapped in IO, add Binding to track how/if Data is bound

* Adds internal.Binding, which is a marker on Elements (subtype/leaves of
Data), that tracks whether a Data has been placed onto the hardware graph
as a register, port, literal, wire, operation result, etc.
* This requires the io of a module actually be explicitly placed on the graph
AS it is being created. (Since the module will want to connect to its own IO,
module close is too late to do the binding.)
* The binding check will also enforce that a bundle constructor does not
actually create logic that is interpreted as part of the 'core bundle'.
* Subsequent CLs will expand upon the Binding system to carry more data
and execute more checks.
* Now, frontend emissions of undefined declarations should be classed as bugs
that should be caught by this system.

Second set of changes:
First, a listing of API changes:
For Literals,
-- You can no longer create a literal with UInt|SInt|Bool.apply(...)
++ Literal UInts/SInts are created from scala Int/BigInt by e.g. 0.asUInt,
myInt.asUInt(5). The latter means forced width to be 5.
++ Literal UInt can also be created from String bu asUInt
++ Literal Bools are created from scala Boolean by e.g. true.asBool
++ The UInt|SInt|Bool factory objects have Lit methods (which is what the old
literal apply methods were renamed to. These are primarily intended for
internal and transitional use. The .as* functions should be preferred.
++ The U|S|B methods added to Int|BigInt|String (identical to asUInt, asSInt, asBool) have been added and marked as deprecated.

For working with Chisel Data,
-- You can no longer supply a direction to UInt|SInt|Bool
-- You can no longer use .asInput|.asOutput|.flip. They have been marked as deprecated.
++ Instead, wrap in Input(), Output(), Flipped() call. These functions can only
be called on unbound data (avoiding extranneous copies)
++ In conjunction with literal changes, UInt(#), SInt(#) now always creates an
unbound variant of that width ie. equivalent to UInt(width=#), etc.

Particularly special notice on cloneType and newType,
-- cloneType is now protected and should not be called by the user
-- The user must still define cloneType (usually) for their cloned Bundles
however the contract has simiplified in that the clone merely must be
'structurally' similar to this.
++ Calling newType will invoke cloneType to get the structural copy and then
return that copy with the directions cleaned up for you.
++ This cleans up a somewhat nasty bug where, for example, direction changes
could get lost when a Vec of a directioned Data was created.
++ Reg and Wire now requires that outType/t variable be unbound (to avoid potential user errors). newType is still called on it so the same Type can be used to create multiple registers and wires.

On connection semantics and directionality,
++ Internal nodes like Reg and Wire that have no defined notion of input or
output direction now lose any direction information when going from Unbound to
Bound. It may be enforced later that the types be explicitly undirectioned.
++ <> is now back to being a bidirectional connect mean to operate between
Module IOs only
++ <> requires Bundles on both sides to have exactly the same fields
++ := is now back to being a monodirectional connect that assumes all
subelements of the RHS are sources for corresponding subelement sinks on the
LHS.
++ := requires the source Bundle to have at least the fields of the sink
Bundle.

In ChiselUtils,
++ EnqIO and DeqIO have been reworked and are no longer distinct classes and
just factory methods for creating an appropriate DecoupledIO
++ Decoupled factory object renamed to DecoupledIO
++ DecoupledIO fire() method renamed to firing
++ DecoupledIO has enq, noenq, deq, nodeq, similar to old EnqIO, DeqIO methods
++ ValidIO type renamed to Valid, no longer forces Output

Second, some notes on implementation changes.
Direction is no longer stored on the Data but on the Binding attached to the
data. The concept of Binding has been enriched to also introduce a 'Binder'
function that a caller users to describe how they want a Data's nodes to be
bound dependent on the specifics of the UnboundBinding. For example, PortBinder
will create a Binding with the same direction information of the
UnboundBinding.

The MonoConnect and BiConnect operators will only emit FIRRTL connections
for Elements, never Aggregates. This is to avoid the issues with FIRRTL
connection semantics. Relatedly, Bundles are never marked as flip or input.
Only Elements of Bundles (or Vec chains of Elements in Bundles) can be marked
as flip. Essentially, all flips have no been distributed through the Bundles to
the root nodes.

Vec types now contain a sample_element that tracks all the binding changes to
the actual elements. This sample_element is used when emitting the type of the
Vec to FIRRTL and when creating a dynamically indexed port. This is needed to
handle the case of an empty Vec having no elements but still requiring those
descriptions. For consistency, this sample_element is used even when the Vec is
not empty.

cloneTypeWidth behavior is somewhat weird. However, this is private and only
used to create operators and should not be an immediate issue. This will
eventually be removed (since cloneTypeWidth previously and currently will not
create appropriate Muxes of Aggregates).

The use of DynamicVariable in Builder has been more carefully hidden from the
rest of the internals by making dynamicContext private and adding accessors to
the other global state.

I want to watch the overhead in cloneType and newType to make sure too much
time isn't being spent making copies, manipulating them, copying again, as so
on as people built more complex types. (Not having Input, Output, Flipped
create a copy was inspired by a desire to avoid these copies)