### PR TITLE
Fix a fairly serious bug whereby Vec's could incorrectly compare as equal

### DIFF
--- a/chiselFrontend/src/main/scala/Chisel/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/Chisel/Aggregate.scala
@@ -174,9 +174,13 @@ sealed class Vec[T <: Data] private (gen: => T, val length: Int)
 /** A trait for [[Vec]]s containing common hardware generators for collection
   * operations.
   */
-trait VecLike[T <: Data] extends collection.IndexedSeq[T] {
+trait VecLike[T <: Data] extends collection.IndexedSeq[T] with HasId {
   def apply(idx: UInt): T
 
+  // IndexedSeq has its own hashCode/equals that we must not use
+  override def hashCode: Int = super[HasId].hashCode
+  override def equals(that: Any): Boolean = super[HasId].equals(that)
+  
   @deprecated("Use Vec.apply instead", "chisel3")
   def read(idx: UInt): T
 

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -41,6 +41,32 @@ class ShiftRegisterTester(n: Int) extends BasicTester {
   }
 }
 
+class FunBundle extends Bundle {
+  val stuff = UInt(width = 10)
+}
+
+class ZeroModule extends Module {
+  val io = new Bundle {
+    val mem = UInt(width = 10)
+    val interrupts = Vec(2, Bool()).asInput
+    val mmio_axi = Vec(0, new FunBundle)
+    val mmio_ahb = Vec(0, new FunBundle).flip
+  }
+  
+  io.mmio_axi <> io.mmio_ahb
+  
+  io.mem := UInt(0)
+  when (io.interrupts(0)) { io.mem := UInt(1) }
+  when (io.interrupts(1)) { io.mem := UInt(2) }
+}
+
+class ZeroTester extends BasicTester {
+  val foo = Module(new ZeroModule)
+  foo.io.interrupts := Vec.tabulate(2) { _ => Bool(true) }
+  assert (foo.io.mem === UInt(2))
+  stop()
+}
+
 class VecSpec extends ChiselPropSpec {
   property("Vecs should be assignable") {
     forAll(safeUIntN(8)) { case(w: Int, v: List[Int]) =>
@@ -54,5 +80,9 @@ class VecSpec extends ChiselPropSpec {
 
   property("Regs of vecs should be usable as shift registers") {
     forAll(smallPosInts) { (n: Int) => assertTesterPasses{ new ShiftRegisterTester(n) } }
+  }
+  
+  property("Dual empty Vectors") {
+    assertTesterPasses{ new ZeroTester }
   }
 }


### PR DESCRIPTION
This bug breaks Bundles with two empty Vectors... if you connect them. This was a latent bug affecting Rocket (utl and ptw in RoCCInterface) as well as any attempts to use multiple optional interfaces in TopIO.