### PR TITLE
Increase the scope of Bundle.namedElts to private[chisel] for testers.

### DIFF
--- a/chiselFrontend/src/main/scala/chisel/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel/core/Aggregate.scala
@@ -315,7 +315,7 @@ class Bundle extends Aggregate(NO_DIR) {
 
   /** Returns a list of elements in this Bundle.
     */
-  private[core] lazy val namedElts = {
+  private[chisel] lazy val namedElts = {
     val nameMap = LinkedHashMap[String, Data]()
     val seen = HashSet[Data]()
     for (m <- getClass.getMethods.sortWith(_.getName < _.getName)) {


### PR DESCRIPTION
This is a temporary fix to re-enable testers (IOAccessor). See #217 