### PR TITLE
Added vec IO tests for #104

### DIFF
--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -74,6 +74,9 @@ class MuxTransform(val c: Context) extends SourceInfoTransformMacro {
 
 class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
+  def apply_ngen(n: c.Tree, gen: c.Tree): c.Tree = {
+    q"$thisObj.do_apply($n,$gen)($implicitSourceInfo)"
+  }
   def apply_elts(elts: c.Tree): c.Tree = {
     q"$thisObj.do_apply($elts)($implicitSourceInfo)"
   }

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -9,12 +9,38 @@ import chisel3._
 import chisel3.testers.BasicTester
 import chisel3.util._
 
+class RegTesterMod( vecSize : Int ) extends Module {
+  val io = new Bundle {
+    val in = Vec( vecSize, UInt( INPUT ) )
+    val out = Vec( vecSize, UInt( OUTPUT ) )
+  }
+  val vecReg = RegInit( Vec( vecSize, UInt( 0 ) ) )
+  vecReg := io.in
+  io.out := vecReg
+}
+
 class IOTesterMod( vecSize : Int ) extends Module {
   val io = new Bundle {
     val in = Vec( vecSize, UInt( INPUT ) )
     val out = Vec( vecSize, UInt( OUTPUT ) )
   }
   io.out := io.in
+}
+
+class RegTester(w: Int, values: List[Int] ) extends BasicTester {
+  val v = Vec(values.map(UInt(_, width = w)))
+  val dut = Module( new RegTesterMod( values.length ) )
+  val doneReg = RegInit( Bool(false) )
+  dut.io.in := v
+  when ( doneReg ) {
+    for ((a,b) <- dut.io.out.zip(values))
+      assert(a === UInt(b))
+    stop()
+  } .otherwise {
+    doneReg := Bool(true)
+    for ( a <- dut.io.out)
+      assert(a === UInt(0))
+  }
 }
 
 class IOTester(w: Int, values: List[Int] ) extends BasicTester {
@@ -121,6 +147,12 @@ class VecSpec extends ChiselPropSpec {
   property("Vecs should be passed through vec IO with fill") {
     forAll(safeUIntN(8)) { case(w: Int, v: List[Int]) =>
       assertTesterPasses{ new IOTesterFill(w, v) }
+    }
+  }
+
+  property("A Reg of a Vec should operate correctly") {
+    forAll(safeUIntN(8)) { case(w: Int, v: List[Int]) =>
+      assertTesterPasses{ new RegTester(w, v) }
     }
   }
 

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -9,13 +9,19 @@ import chisel3._
 import chisel3.testers.BasicTester
 import chisel3.util._
 
+class LitTesterMod( vecSize : Int ) extends Module {
+  val io = new Bundle {
+    val out = Vec( vecSize, UInt( OUTPUT ) )
+  }
+  io.out := Vec( vecSize, UInt( 0 ) )
+}
+
 class RegTesterMod( vecSize : Int ) extends Module {
   val io = new Bundle {
     val in = Vec( vecSize, UInt( INPUT ) )
     val out = Vec( vecSize, UInt( OUTPUT ) )
   }
-  val vecReg = RegInit( Vec( vecSize, UInt( 0 ) ) )
-  vecReg := io.in
+  val vecReg = Reg( init = Vec( vecSize, UInt( 0 ) ), next = io.in )
   io.out := vecReg
 }
 
@@ -25,6 +31,13 @@ class IOTesterMod( vecSize : Int ) extends Module {
     val out = Vec( vecSize, UInt( OUTPUT ) )
   }
   io.out := io.in
+}
+
+class LitTester(w: Int, values: List[Int] ) extends BasicTester {
+  val dut = Module( new LitTesterMod( values.length ) )
+  for ( a <- dut.io.out)
+    assert(a === UInt(0))
+  stop()
 }
 
 class RegTester(w: Int, values: List[Int] ) extends BasicTester {
@@ -153,6 +166,12 @@ class VecSpec extends ChiselPropSpec {
   property("A Reg of a Vec should operate correctly") {
     forAll(safeUIntN(8)) { case(w: Int, v: List[Int]) =>
       assertTesterPasses{ new RegTester(w, v) }
+    }
+  }
+
+  property("A Vec of lit should operate correctly") {
+    forAll(safeUIntN(8)) { case(w: Int, v: List[Int]) =>
+      assertTesterPasses{ new LitTester(w, v) }
     }
   }
 


### PR DESCRIPTION
Add test cases for #104, #109 fixes Vec( vecSize, UInt( INPUT ) ) but not Vec.fill( vecSize ) { UInt(INPUT) }
Also fails for RegInit( Vec(vecSize, UInt( 0 ) )
