### PR TITLE
Add a tree reduce function to Vec

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -206,7 +206,7 @@ sealed class Vec[T <: Data] private (gen: => T, val length: Int)
   def do_reduce( redOp : ( T, T ) => T, layerOp : ( T ) => T )(implicit sourceInfo: SourceInfo) : T = {
     var curLayer = this
     while ( curLayer.length > 1 )
-      curLayer = curLayer.do_treeLayerReduce( redOp, layerOp )
+      curLayer = curLayer.do_pair( redOp, layerOp )
     require( curLayer.length == 1, "Cannot apply reduction on a vec of size 0" )
     curLayer(0)
   }

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -89,9 +89,6 @@ class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   def contains(x: c.Tree)(ev: c.Tree): c.Tree = {
     q"$thisObj.do_contains($x)($implicitSourceInfo, $ev)"
   }
-  def pair(redOp: c.Tree, layerOp: c.Tree): c.Tree = {
-    q"$thisObj.do_pair($redOp,$layerOp)($implicitSourceInfo)"
-  }
   def reduce(redOp: c.Tree, layerOp: c.Tree): c.Tree = {
     q"$thisObj.do_reduce($redOp,$layerOp)($implicitSourceInfo)"
   }

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -89,6 +89,12 @@ class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   def contains(x: c.Tree)(ev: c.Tree): c.Tree = {
     q"$thisObj.do_contains($x)($implicitSourceInfo, $ev)"
   }
+  def treeLayerReduce(redOp: c.Tree, layerOp: c.Tree): c.Tree = {
+    q"$thisObj.do_treeLayerReduce($redOp,$layerOp)($implicitSourceInfo)"
+  }
+  def treeReduce(redOp: c.Tree, layerOp: c.Tree): c.Tree = {
+    q"$thisObj.do_treeReduce($redOp,$layerOp)($implicitSourceInfo)"
+  }
 }
 
 /** "Automatic" source information transform / insertion macros, which generate the function name

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -92,8 +92,8 @@ class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   def treeLayerReduce(redOp: c.Tree, layerOp: c.Tree): c.Tree = {
     q"$thisObj.do_treeLayerReduce($redOp,$layerOp)($implicitSourceInfo)"
   }
-  def treeReduce(redOp: c.Tree, layerOp: c.Tree): c.Tree = {
-    q"$thisObj.do_treeReduce($redOp,$layerOp)($implicitSourceInfo)"
+  def reduce(redOp: c.Tree, layerOp: c.Tree): c.Tree = {
+    q"$thisObj.do_reduce($redOp,$layerOp)($implicitSourceInfo)"
   }
 }
 

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -89,8 +89,11 @@ class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   def contains(x: c.Tree)(ev: c.Tree): c.Tree = {
     q"$thisObj.do_contains($x)($implicitSourceInfo, $ev)"
   }
-  def reduce(redOp: c.Tree, layerOp: c.Tree): c.Tree = {
-    q"$thisObj.do_reduce($redOp,$layerOp)($implicitSourceInfo)"
+  def reduceTree(redOp: c.Tree, layerOp: c.Tree): c.Tree = {
+    q"$thisObj.do_reduceTree($redOp,$layerOp)($implicitSourceInfo)"
+  }
+  def reduceTreeDefault(redOp: c.Tree ): c.Tree = {
+    q"$thisObj.do_reduceTree($redOp)($implicitSourceInfo)"
   }
 }
 

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -89,8 +89,8 @@ class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   def contains(x: c.Tree)(ev: c.Tree): c.Tree = {
     q"$thisObj.do_contains($x)($implicitSourceInfo, $ev)"
   }
-  def treeLayerReduce(redOp: c.Tree, layerOp: c.Tree): c.Tree = {
-    q"$thisObj.do_treeLayerReduce($redOp,$layerOp)($implicitSourceInfo)"
+  def pair(redOp: c.Tree, layerOp: c.Tree): c.Tree = {
+    q"$thisObj.do_pair($redOp,$layerOp)($implicitSourceInfo)"
   }
   def reduce(redOp: c.Tree, layerOp: c.Tree): c.Tree = {
     q"$thisObj.do_reduce($redOp,$layerOp)($implicitSourceInfo)"

--- a/src/test/scala/chiselTests/AdderTree.scala
+++ b/src/test/scala/chiselTests/AdderTree.scala
@@ -13,7 +13,7 @@ class AdderTree[ T <: Bits with Num[T] ]( genType : T, vecSize : Int ) extends M
     val numIn = Vec( vecSize, genType ).asInput
     val numOut = genType.cloneType.asOutput
   }
-  io.numOut := io.numIn.treeReduce(
+  io.numOut := io.numIn.reduce(
     (a : T, b : T) => ( a + b ),
     ( a : T ) => ( a ) )
 }

--- a/src/test/scala/chiselTests/AdderTree.scala
+++ b/src/test/scala/chiselTests/AdderTree.scala
@@ -13,9 +13,8 @@ class AdderTree[ T <: Bits with Num[T] ]( genType : T, vecSize : Int ) extends M
     val numIn = Vec( vecSize, genType ).asInput
     val numOut = genType.cloneType.asOutput
   }
-  io.numOut := io.numIn.reduce(
-    (a : T, b : T) => ( a + b ),
-    ( a : T ) => ( a ) )
+  io.numOut := io.numIn.reduceTree(
+    (a : T, b : T) => ( a + b ) )
 }
 
 class AdderTreeTester( bitWidth : Int, numsToAdd : List[Int] ) extends BasicTester {

--- a/src/test/scala/chiselTests/AdderTree.scala
+++ b/src/test/scala/chiselTests/AdderTree.scala
@@ -1,0 +1,41 @@
+package chiselTests
+
+import chisel3._
+import chisel3.util._
+import chisel3.testers.BasicTester
+import org.scalatest._
+import org.scalacheck._
+import org.scalatest.prop._
+import scala.collection.mutable.ArrayBuffer
+
+class AdderTree[ T <: Bits with Num[T] ]( genType : T, vecSize : Int ) extends Module {
+  val io = new Bundle {
+    val numIn = Vec( vecSize, genType ).asInput
+    val numOut = genType.cloneType.asOutput
+  }
+  io.numOut := io.numIn.treeReduce(
+    (a : T, b : T) => ( a + b ),
+    ( a : T ) => ( a ) )
+}
+
+class AdderTreeTester( bitWidth : Int, numsToAdd : List[Int] ) extends BasicTester {
+  println("numsToAdd.size = " + numsToAdd.size )
+  val genType = UInt( width = bitWidth )
+  val dut = Module( new AdderTree( genType, numsToAdd.size ) )
+  dut.io.numIn := Vec(numsToAdd.map(x => UInt(x, bitWidth)))
+  val sumCorrect = dut.io.numOut === UInt( numsToAdd.reduce(_+_) % (1 << bitWidth ), bitWidth )
+  assert(sumCorrect)
+  stop()
+}
+
+class AdderTreeSpec extends ChiselPropSpec {
+  property("All numbers should be added correctly by an Adder Tree") {
+    forAll( safeUIntN( 20 ) ) {
+      case(w: Int, v: List[Int]) => {
+        whenever ( v.size > 0 && w > 0 ) {
+          assertTesterPasses{ new AdderTreeTester( w, v.map(x => math.abs(x) % ( 1 << w ) ).toList ) }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added a few tree reduce operations.
I find I need this structure reduce more than reduceLeft/reduceRight and i think it makes sense to add it to Vec.

I also see a use case for a single layer reduce. For example, to implement some form of time multiplexing on a vec:

``` scala
val outputVec = inputVec.treeLayerReduce(
                         ( a : T, b : T ) => RegNext(Mux( myCond, a, b )),
                         ( a : T ) => RegNext( a ) )
```

Thoughts?
