### PR TITLE
Add support for per-Module compilation options.

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -97,12 +97,16 @@ private[chisel3] trait HasId {
   private[chisel3] def getRef: Arg = _ref.get
 }
 
-private[chisel3] class DynamicContext {
+private[chisel3] class DynamicContext(optionMap: Option[Map[String, String]] = None) {
   val idGen = new IdGen
   val globalNamespace = new Namespace(None, Set())
   val components = ArrayBuffer[Component]()
   var currentModule: Option[Module] = None
   val errors = new ErrorLog
+  val compileOptions = new CompileOptions(optionMap match {
+    case Some(map: Map[String, String]) => map
+    case None => Map[String, String]()
+  })
 }
 
 private[chisel3] object Builder {
@@ -115,6 +119,7 @@ private[chisel3] object Builder {
   def globalNamespace: Namespace = dynamicContext.globalNamespace
   def components: ArrayBuffer[Component] = dynamicContext.components
 
+  def compileOptions = dynamicContext.compileOptions
   def pushCommand[T <: Command](c: T): T = {
     dynamicContext.currentModule.foreach(_._commands += c)
     c
@@ -124,8 +129,8 @@ private[chisel3] object Builder {
   def errors: ErrorLog = dynamicContext.errors
   def error(m: => String): Unit = errors.error(m)
 
-  def build[T <: Module](f: => T): Circuit = {
-    dynamicContextVar.withValue(Some(new DynamicContext)) {
+  def build[T <: Module](f: => T, optionMap: Option[Map[String, String]] = None): Circuit = {
+    dynamicContextVar.withValue(Some(new DynamicContext(optionMap))) {
       errors.info("Elaborating design...")
       val mod = f
       mod.forceName(mod.name, globalNamespace)

--- a/chiselFrontend/src/main/scala/chisel3/internal/CompileOptions.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/CompileOptions.scala
@@ -1,0 +1,16 @@
+// See LICENSE for license details.
+
+package chisel3.internal
+
+/** Initialize compilation options from a string map.
+  *
+  * @param optionsMap the map from "option" to "value"
+  */
+class CompileOptions(optionsMap: Map[String, String]) {
+  // The default for settings related to "strictness".
+  val strictDefault: String = optionsMap.getOrElse("strict", "false")
+  // Should Bundle connections require a strict match of fields.
+  // If true and the same fields aren't present in both source and sink, a MissingFieldException,
+  // MissingLeftFieldException, or MissingRightFieldException will be thrown.
+  val connectFieldsMustMatch: Boolean = optionsMap.getOrElse("connectFieldsMustMatch", strictDefault).toBoolean
+}


### PR DESCRIPTION
Nothing uses these now, but when we integrate Stephen's PR200, we'll need a way to selectively enable some strict connection checks on a file by file basis. We plan to do this using package imports which will define suitable compilation options.