### PR TITLE
Make "def width" a private API; expose isWidthKnown instead

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -373,5 +373,6 @@ class Bundle extends Aggregate(NO_DIR) {
 }
 
 private[core] object Bundle {
-  val keywords = List("flip", "asInput", "asOutput", "cloneType", "toBits")
+  val keywords = List("flip", "asInput", "asOutput", "cloneType", "toBits",
+                      "widthOption")
 }

--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -16,7 +16,7 @@ import chisel3.internal.sourceinfo.{SourceInfo, DeprecatedSourceInfo, VecTransfo
   */
 sealed abstract class Aggregate(dirArg: Direction) extends Data(dirArg) {
   private[core] def cloneTypeWidth(width: Width): this.type = cloneType
-  def width: Width = flatten.map(_.width).reduce(_ + _)
+  private[core] def width: Width = flatten.map(_.width).reduce(_ + _)
 }
 
 object Vec {

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -14,7 +14,7 @@ import chisel3.internal.firrtl.PrimOp._
 /** Element is a leaf data type: it cannot contain other Data objects. Example
   * uses are for representing primitive data types, like integers and bits.
   */
-abstract class Element(dirArg: Direction, val width: Width) extends Data(dirArg)
+abstract class Element(dirArg: Direction, private[core] val width: Width) extends Data(dirArg)
 
 /** A data type for values represented by a single bitvector. Provides basic
   * bitwise operations.

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -72,6 +72,8 @@ abstract class Data(dirArg: Direction) extends HasId {
   final def getWidth: Int = width.get
   /** Returns whether the width is currently known. */
   final def isWidthKnown: Boolean = width.known
+  /** Returns Some(width) if the width is known, else None. */
+  final def widthOption: Option[Int] = if (isWidthKnown) Some(getWidth) else None
 
   // While this being in the Data API doesn't really make sense (should be in
   // Aggregate, right?) this is because of an implementation limitation:

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -56,6 +56,7 @@ abstract class Data(dirArg: Direction) extends HasId {
   private[chisel3] def ref: Arg = if (isLit) litArg.get else lref
   private[core] def cloneTypeWidth(width: Width): this.type
   private[chisel3] def toType: String
+  private[core] def width: Width
 
   def := (that: Data)(implicit sourceInfo: SourceInfo): Unit = this badConnect that
 
@@ -66,8 +67,10 @@ abstract class Data(dirArg: Direction) extends HasId {
   def litValue(): BigInt = litArg.get.num
   def isLit(): Boolean = litArg.isDefined
 
-  private[core] def width: Width
+  /** Returns the width, in bits, if currently known.
+    * @throws java.util.NoSuchElementException if the width is not known. */
   final def getWidth: Int = width.get
+  /** Returns whether the width is currently known. */
   final def isWidthKnown: Boolean = width.known
 
   // While this being in the Data API doesn't really make sense (should be in

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -66,8 +66,9 @@ abstract class Data(dirArg: Direction) extends HasId {
   def litValue(): BigInt = litArg.get.num
   def isLit(): Boolean = litArg.isDefined
 
-  def width: Width
+  private[core] def width: Width
   final def getWidth: Int = width.get
+  final def isWidthKnown: Boolean = width.known
 
   // While this being in the Data API doesn't really make sense (should be in
   // Aggregate, right?) this is because of an implementation limitation:

--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -68,7 +68,7 @@ object BitPat {
     */
   def apply(x: UInt): BitPat = {
     require(x.isLit)
-    val len = if (x.width.known) x.getWidth else 0
+    val len = if (x.isWidthKnown) x.getWidth else 0
     apply("b" + x.litValue.toString(2).reverse.padTo(len, "0").reverse.mkString)
   }
 }

--- a/src/main/scala/chisel3/util/Bitwise.scala
+++ b/src/main/scala/chisel3/util/Bitwise.scala
@@ -29,7 +29,7 @@ object Fill {
     n match {
       case 0 => UInt(width=0)
       case 1 => x
-      case _ if x.width.known && x.getWidth == 1 =>
+      case _ if x.isWidthKnown && x.getWidth == 1 =>
         Mux(x.toBool, UInt((BigInt(1) << n) - 1, n), UInt(0, n))
       case _ if n > 1 =>
         val p2 = Array.ofDim[UInt](log2Up(n + 1))

--- a/src/test/scala/chiselTests/Reg.scala
+++ b/src/test/scala/chiselTests/Reg.scala
@@ -16,7 +16,7 @@ class RegSpec extends ChiselFlatSpec {
   "A Reg" should "be of the same type and width as outType, if specified" in {
     class RegOutTypeWidthTester extends BasicTester {
       val reg = Reg(t=UInt(width=2), next=UInt(width=3), init=UInt(20))
-      reg.width.get should be (2)
+      reg.getWidth should be (2)
     }
     elaborate{ new RegOutTypeWidthTester }
   }
@@ -24,11 +24,11 @@ class RegSpec extends ChiselFlatSpec {
   "A Reg" should "be of unknown width if outType is not specified and width is not forced" in {
     class RegUnknownWidthTester extends BasicTester {
       val reg1 = Reg(next=UInt(width=3), init=UInt(20))
-      reg1.width.known should be (false)
+      reg1.isWidthKnown should be (false)
       val reg2 = Reg(init=UInt(20))
-      reg2.width.known should be (false)
+      reg2.isWidthKnown should be (false)
       val reg3 = Reg(next=UInt(width=3), init=UInt(width=5))
-      reg3.width.known should be (false)
+      reg3.isWidthKnown should be (false)
     }
     elaborate { new RegUnknownWidthTester }
   }
@@ -36,7 +36,7 @@ class RegSpec extends ChiselFlatSpec {
   "A Reg" should "be of width of init if outType and next are missing and init is a literal of forced width" in {
     class RegForcedWidthTester extends BasicTester {
       val reg2 = Reg(init=UInt(20, width=7))
-      reg2.width.get should be (7)
+      reg2.getWidth should be (7)
     }
     elaborate{ new RegForcedWidthTester }
   }


### PR DESCRIPTION
Resolves #256.

Since width was used to determine whether getWidth would succeed, I added

    def isWidthKnown: Boolean

but another option would be to expose something like

    def widthOption: Option[Int]

...thoughts?