### PR TITLE
Public APIs for chisel object names

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -374,4 +374,5 @@ class Bundle extends Aggregate(NO_DIR) {
 
 private[core] object Bundle {
   val keywords = List("flip", "asInput", "asOutput", "cloneType", "toBits",
-   "widthOption", "signalName", "signalPathName", "signalParent", "signalComponent")
+    "widthOption", "signalName", "signalPathName", "signalParent", "signalComponent")
+}

--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -374,5 +374,4 @@ class Bundle extends Aggregate(NO_DIR) {
 
 private[core] object Bundle {
   val keywords = List("flip", "asInput", "asOutput", "cloneType", "toBits",
-                      "widthOption")
-}
+   "widthOption", "signalName", "signalPathName", "signalParent", "signalComponent")

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -63,6 +63,9 @@ extends HasId {
   /** Legalized name of this module. */
   final val name = Builder.globalNamespace.name(desiredName)
 
+  /** Signal name (for simulation). */
+  override def signalName(component: Component) = name
+
   /** IO for this Module. At the Scala level (pre-FIRRTL transformations),
     * connections in and out of a Module may only go through `io` elements.
     */

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -78,7 +78,7 @@ extends HasId {
 
 
   /** Signal name (for simulation). */
-  override def signalName =
+  override def instanceName =
     if (_parent == None) name else _component match {
       case None => getRef.name
       case Some(c) => getRef fullName c

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -31,7 +31,9 @@ object Module {
     m._commands.prepend(DefInvalid(childSourceInfo, m.io.ref)) // init module outputs
     dynamicContext.currentModule = parent
     val ports = m.computePorts
-    Builder.components += Component(m, m.name, ports, m._commands)
+    val component = Component(m, m.name, ports, m._commands)
+    m._component = Some(component)
+    Builder.components += component
     pushCommand(DefInstance(sourceInfo, m, ports))
     m.setupInParent(childSourceInfo)
   }
@@ -63,8 +65,24 @@ extends HasId {
   /** Legalized name of this module. */
   final val name = Builder.globalNamespace.name(desiredName)
 
+  /** FIRRTL Module name */
+  private var _modName: Option[String] = None
+  private[chisel3] def setModName(name: String) = _modName = Some(name)
+  def modName = _modName match {
+    case Some(name) => name
+    case None => throwException("modName should be called after circuit elaboration")
+  }
+
+  /** Keep component for signal names */
+  private[chisel3] var _component: Option[Component] = None
+
+
   /** Signal name (for simulation). */
-  override def signalName(component: Component) = name
+  override def signalName =
+    if (_parent == None) name else _component match {
+      case None => getRef.name
+      case Some(c) => getRef fullName c
+    }
 
   /** IO for this Module. At the Scala level (pre-FIRRTL transformations),
     * connections in and out of a Module may only go through `io` elements.

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -55,13 +55,15 @@ private[chisel3] class IdGen {
   }
 }
 
-/** Public API to Nodes.
-  * currently, the node's name, the full path name, and a reference to its parent.
+/** Public API to access Node/Signal names.
+  * currently, the node's name, the full path name, and references to its parent Module and component.
+  * These are only valid once the design has been elaborated, and should not be used during its construction.
   */
 trait SignalID {
   def signalName(component: Component): String
-  def signalPathName(component: Component, separator: String = "_"): String
+  def signalPathName(component: Component, separator: String = "."): String
   def signalParent: Module
+  def signalComponent: Option[Component]
 }
 
 private[chisel3] trait HasId extends SignalID {
@@ -78,6 +80,7 @@ private[chisel3] trait HasId extends SignalID {
       case None => signalName(component)
     }
   }
+  override def signalComponent: Option[Component] = None
 
   private[chisel3] val _id = Builder.idGen.next
   override def hashCode: Int = _id.toInt

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -59,14 +59,14 @@ private[chisel3] class IdGen {
   * currently, the node's name, the full path name, and references to its parent Module and component.
   * These are only valid once the design has been elaborated, and should not be used during its construction.
   */
-trait SignalId {
-  def signalName: String
+trait InstanceId {
+  def instanceName: String
   def pathName: String
   def parentPathName: String
   def parentModName: String
 }
 
-private[chisel3] trait HasId extends SignalId {
+private[chisel3] trait HasId extends InstanceId {
   private[chisel3] def _onModuleClose {} // scalastyle:ignore method.name
   private[chisel3] val _parent = Builder.dynamicContext.currentModule
   _parent.foreach(_.addId(this))
@@ -108,7 +108,7 @@ private[chisel3] trait HasId extends SignalId {
   private[chisel3] def getRef: Arg = _ref.get
 
   // Implementation of public methods.
-  def signalName = _parent match {
+  def instanceName = _parent match {
     case Some(p) => p._component match {
       case Some(c) => getRef fullName c
       case None => throwException("signalName/pathName should be called after circuit elaboration")
@@ -116,16 +116,16 @@ private[chisel3] trait HasId extends SignalId {
     case None => throwException("this cannot happen")
   }
   def pathName = _parent match {
-    case None => signalName
-    case Some(p) => s"${p.pathName}.$signalName"
+    case None => instanceName
+    case Some(p) => s"${p.pathName}.$instanceName"
   }
   def parentPathName = _parent match {
     case Some(p) => p.pathName
-    case None => throwException(s"$signalName doesn't have a parent")
+    case None => throwException(s"$instanceName doesn't have a parent")
   }
   def parentModName = _parent match {
     case Some(p) => p.modName
-    case None => throwException(s"$signalName doesn't have a parent")
+    case None => throwException(s"$instanceName doesn't have a parent")
   }
 }
 

--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -112,6 +112,8 @@ object Driver extends BackendCompilationUtilities {
 
   def emit[T <: Module](gen: () => T): String = Emitter.emit(elaborate(gen))
 
+  def emit[T <: Module](ir: Circuit): String = Emitter.emit(ir)
+
   def dumpFirrtl(ir: Circuit, optName: Option[File]): File = {
     val f = optName.getOrElse(new File(ir.name + ".fir"))
     val w = new FileWriter(f)

--- a/src/main/scala/chisel3/internal/firrtl/Emitter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Emitter.scala
@@ -87,7 +87,7 @@ private class Emitter(circuit: Circuit) {
         ""
       case None =>
         defnMap((m.id.desiredName, defn)) = m
-        m.id setModName m.id.name
+        m.id setModName m.name
         moduleDecl(m) + defn
     }
   }

--- a/src/main/scala/chisel3/internal/firrtl/Emitter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Emitter.scala
@@ -27,11 +27,7 @@ private class Emitter(circuit: Circuit) {
       case e: Stop => s"stop(${e.clk.fullName(ctx)}, UInt<1>(1), ${e.ret})"
       case e: Printf => s"""printf(${e.clk.fullName(ctx)}, UInt<1>(1), "${e.format}"${e.ids.map(_.fullName(ctx)).fold(""){_ + ", " + _}})"""
       case e: DefInvalid => s"${e.arg.fullName(ctx)} is invalid"
-      case e: DefInstance => {
-        val modName = moduleMap.get(e.id.name).get
-        s"inst ${e.name} of $modName"
-      }
-
+      case e: DefInstance => s"inst ${e.name} of ${e.id.modName}"
       case w: WhenBegin =>
         indent()
         s"when ${w.pred.fullName(ctx)} :"
@@ -47,8 +43,6 @@ private class Emitter(circuit: Circuit) {
 
   // Map of Module FIRRTL definition to FIRRTL name, if it has been emitted already.
   private val defnMap = collection.mutable.HashMap[(String, String), Component]()
-  // Map of Component name to FIRRTL id.
-  private val moduleMap = collection.mutable.HashMap[String, String]()
 
   /** Generates the FIRRTL module declaration.
     */
@@ -89,15 +83,11 @@ private class Emitter(circuit: Circuit) {
 
     defnMap get (m.id.desiredName, defn) match {
       case Some(duplicate) =>
-        moduleMap(m.name) = duplicate.name
+        m.id setModName duplicate.name
         ""
       case None =>
-        require(!(moduleMap contains m.name),
-            "emitting module with same name but different contents")
-
-        moduleMap(m.name) = m.name
         defnMap((m.id.desiredName, defn)) = m
-
+        m.id setModName m.id.name
         moduleDecl(m) + defn
     }
   }

--- a/src/test/scala/chiselTests/AnnotatingExample.scala
+++ b/src/test/scala/chiselTests/AnnotatingExample.scala
@@ -1,0 +1,115 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.core.Module
+import chisel3.internal.Builder
+import chisel3.internal.firrtl.{Emitter, Circuit}
+import chisel3.testers.BasicTester
+import org.scalatest._
+import org.scalatest.prop._
+
+import scala.util.DynamicVariable
+
+class SomeSubMod extends Module {
+  val io = new Bundle {
+    val in = UInt(INPUT, 16)
+    val out = SInt(OUTPUT, 32)
+  }
+  MyBuilder.myDynamicContext.annotationMap(AnnotationKey(io.in, AllRefs))  = "sub mod io.in"
+  MyBuilder.myDynamicContext.annotationMap(AnnotationKey(io.out, JustThisRef)) = "sub mod io.out"
+}
+
+class AnnotatingExample extends Module {
+  val io = new Bundle {
+    val a  = UInt(INPUT, 32)
+    val b  = UInt(INPUT, 32)
+    val e  = Bool(INPUT)
+    val z  = UInt(OUTPUT, 32)
+    val v  = Bool(OUTPUT)
+    val bun = new Bundle {
+      val nested_1 = UInt(INPUT, 12)
+      val nested_2 = Bool(OUTPUT)
+    }
+  }
+  val x = Reg(UInt(width = 32))
+  val y = Reg(UInt(width = 32))
+
+  val subModule1 = Module(new SomeSubMod)
+  val subModule2 = Module(new SomeSubMod)
+
+
+  val annotate = MyBuilder.myDynamicContext.annotationMap
+
+  annotate(AnnotationKey(x, JustThisRef)) = "I am register X"
+  annotate(AnnotationKey(io.a, JustThisRef)) = "I am io.a"
+  annotate(AnnotationKey(io.bun.nested_1, JustThisRef)) = "I am io.bun.nested_1"
+  annotate(AnnotationKey(io.bun.nested_2, JustThisRef)) = "I am io.bun.nested_2"
+
+  when (x > y)   { x := x -% y }
+  .otherwise     { y := y -% x }
+  when (io.e) { x := io.a; y := io.b }
+  io.z := x
+  io.v := y === UInt(0)
+}
+
+class AnnotatingExampleTester(a: Int, b: Int, z: Int) extends BasicTester {
+  val dut = Module(new AnnotatingExample)
+  val first = Reg(init=Bool(true))
+  dut.io.a := UInt(a)
+  dut.io.b := UInt(b)
+  dut.io.e := first
+  when(first) { first := Bool(false) }
+  when(!first && dut.io.v) {
+    assert(dut.io.z === UInt(z))
+    stop()
+  }
+}
+
+class AnnotatingExampleSpec extends ChiselPropSpec {
+
+  property("show node info") {
+    MyDriver.doStuff { () => new AnnotatingExampleTester(1, 2, 3) }
+  }
+
+}
+
+trait AnnotationScope
+case object Default extends AnnotationScope
+case object AllRefs extends AnnotationScope
+case object JustThisRef extends AnnotationScope
+
+case class AnnotationKey(val component: Data, scope: AnnotationScope)
+
+class MyDynamicContext {
+  val annotationMap = new scala.collection.mutable.HashMap[AnnotationKey, String]
+}
+
+object MyBuilder {
+  private val myDynamicContextVar = new DynamicVariable[Option[MyDynamicContext]](None)
+
+  def myDynamicContext: MyDynamicContext =
+    myDynamicContextVar.value getOrElse (new MyDynamicContext)
+
+  def build[T <: Module](f: => T): Unit = {
+    myDynamicContextVar.withValue(Some(new MyDynamicContext)) {
+      Driver.emit(() => f)
+      val list = myDynamicContextVar.value.get.annotationMap.map { case (k,v) =>
+        k match {
+          case (AnnotationKey(signal, JustThisRef)) =>
+            f"Just this ref ${signal.pathName + signal.signalName}%60s -> $v%30s  component $signal"
+          case (AnnotationKey(signal, AllRefs)) =>
+            f"All refs      ${signal.signalName}%60s -> $v%30s  component $signal"
+          case  _ =>
+            s"Unknown annotation key $k"
+        }
+      }.toList.sorted
+      println(list.mkString("\n"))
+    }
+  }
+}
+
+object MyDriver extends BackendCompilationUtilities {
+  def doStuff[T <: Module](gen: () => T): Unit = MyBuilder.build(Module(gen()))
+}

--- a/src/test/scala/chiselTests/AnnotatingExample.scala
+++ b/src/test/scala/chiselTests/AnnotatingExample.scala
@@ -4,7 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.core.Module
-import chisel3.internal.SignalId
+import chisel3.internal.InstanceId
 import chisel3.testers.BasicTester
 import org.scalatest._
 
@@ -96,17 +96,17 @@ case object AllRefs     extends AnnotationScope
 case object JustThisRef extends AnnotationScope
 
 object AnnotationKey {
-  def apply(component: SignalId): AnnotationKey = {
+  def apply(component: InstanceId): AnnotationKey = {
     AnnotationKey(component, AllRefs)
   }
 }
-case class AnnotationKey(val component: SignalId, scope: AnnotationScope) {
+case class AnnotationKey(val component: InstanceId, scope: AnnotationScope) {
   override def toString: String = {
     scope match {
       case JustThisRef =>
         s"${component.pathName}"
       case AllRefs =>
-        s"${component.parentModName}.${component.signalName}"
+        s"${component.parentModName}.${component.instanceName}"
       case  _ =>
         s"${component.toString}_unknown_scope"
     }


### PR DESCRIPTION
From discussion with @chick, @ucbjrl, and @azidar, this change provides chisel obejct names for FIRRTL annotation and chisel testers. Chisel's internal `HasId` now extends `Signald` having four public methods:
* `signalName`: returns the CHIRRTL name of the signal
* `pathName`: returns the full path name of the signal from the top module
* `parentPathName`: returns the full path of the signal's parent module instance from the top module
* `parentModName`: returns the signal's parent **module(not instance)** name. This is not final until CHIRRTL is actually emitted because duplication checks are done in this stage.

To annotate chisel objects and pass them to FIRRTL, users may have containers of `SignalId` and create annotation for signals with `signalName` and `parentModName` after CHIRRTL is emitted by Chisel Driver.  Also, path names are useful for various cases including chisel testers.