### PR TITLE
Make sure RRArbiter's lastGrant has an initial value

### DIFF
--- a/src/main/scala/chisel3/util/Arbiter.scala
+++ b/src/main/scala/chisel3/util/Arbiter.scala
@@ -55,7 +55,7 @@ abstract class LockingArbiterLike[T <: Data](gen: T, n: Int, count: Int, needsLo
 
 class LockingRRArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T => Bool] = None)
     extends LockingArbiterLike[T](gen, n, count, needsLock) {
-  lazy val lastGrant = RegEnable(io.chosen, io.out.fire())
+  lazy val lastGrant = RegEnable(io.chosen, UInt(0), io.out.fire())
   lazy val grantMask = (0 until n).map(UInt(_) > lastGrant)
   lazy val validMask = io.in zip grantMask map { case (in, g) => in.valid && g }
 


### PR DESCRIPTION
The round robin arbiter uses a register to determine which of its inputs gets priority. It's set based on which one was last accepted. The initial value does not really matter, but we shouldn't rely on random initialization to set it in simulation, since that could be turned off.