### PR TITLE
Add Printable

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -169,6 +169,17 @@ sealed class Vec[T <: Data] private (gen: => T, val length: Int)
 
   for ((elt, i) <- self zipWithIndex)
     elt.setRef(this, i)
+
+  /** Default "pretty-print" implementation
+    * Analogous to printing a Seq
+    * Results in "Vec(elt0, elt1, ...)"
+    */
+  def toPrintable: Printable = {
+    val elts =
+      if (length == 0) List.empty[Printable]
+      else self flatMap (e => List(e.toPrintable, PString(", "))) dropRight 1
+    PString("Vec(") + Printables(elts) + PString(")")
+  }
 }
 
 /** A trait for [[Vec]]s containing common hardware generators for collection
@@ -369,6 +380,21 @@ class Bundle extends Aggregate(NO_DIR) {
         Builder.error(s"Parameterized Bundle ${this.getClass} needs cloneType method")
         this
     }
+  }
+
+  /** Default "pretty-print" implementation
+    * Analogous to printing a Map
+    * Results in "Bundle(elt0.name -> elt0.value, ...)"
+    */
+  def toPrintable: Printable = {
+    val elts =
+      if (elements.isEmpty) List.empty[Printable]
+      else {
+        elements.toList.reverse flatMap { case (name, data) =>
+          List(PString(s"$name -> "), data.toPrintable, PString(", "))
+        } dropRight 1 // Remove trailing ", "
+      }
+    PString("Bundle(") + Printables(elts) + PString(")")
   }
 }
 

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -249,6 +249,9 @@ sealed abstract class Bits(dirArg: Direction, width: Width, override val litArg:
     res := that
     res
   }
+
+  /** Default print as [[Decimal]] */
+  final def toPrintable: Printable = Decimal(this)
 }
 
 /** Provides a set of operations to create UInt types and literals.

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -132,6 +132,9 @@ abstract class Data(dirArg: Direction) extends HasId {
 
   def do_asUInt(implicit sourceInfo: SourceInfo): UInt =
     SeqUtils.do_asUInt(this.flatten)(sourceInfo)
+
+  /** Default pretty printing */
+  def toPrintable: Printable
 }
 
 object Wire {
@@ -171,4 +174,7 @@ sealed class Clock(dirArg: Direction) extends Element(dirArg, Width(1)) {
     case _: Clock => this connect that
     case _ => this badConnect that
   }
+
+  /** Not really supported */
+  def toPrintable: Printable = PString("CLOCK")
 }

--- a/chiselFrontend/src/main/scala/chisel3/core/Printable.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Printable.scala
@@ -1,0 +1,150 @@
+// See LICENSE for license details.
+
+package chisel3.core
+
+import chisel3.internal.firrtl.Component
+import chisel3.internal.HasId
+
+import scala.collection.mutable
+
+import java.util.{
+  MissingFormatArgumentException,
+  UnknownFormatConversionException
+}
+
+/** Superclass of things that can be printed in the resulting circuit
+  *
+  * Usually created using the custom string interpolator p"..."
+  * TODO Should we provide more functions like map and mkPrintable?
+  */
+sealed abstract class Printable {
+  /** Unpack into format String and a List of String arguments (identifiers)
+    * @note This must be called after elaboration when Chisel nodes actually
+    *   have names
+    */
+  def unpack: (String, Iterable[String])
+  /** Allow for appending Printables like Strings */
+  final def +(that: Printable) = Printables(List(this, that))
+  /** Allow for appending Strings to Printables */
+  final def +(that: String) = Printables(List(this, PString(that)))
+}
+object Printable {
+  /** Pack standard printf fmt, args* style into Printable
+    */
+  def pack(fmt: String, data: Data*): Printable = {
+    val args = data.toIterator
+
+    // Error handling
+    def carrotAt(index: Int) = (" " * index) + "^"
+    def errorMsg(index: Int) =
+      s"""|    fmt = "$fmt"
+          |           ${carrotAt(index)}
+          |    data = ${data mkString ", "}""".stripMargin
+    def getArg(i: Int): Data = {
+      if (!args.hasNext) {
+        val msg = "has no matching argument!\n" + errorMsg(i)
+          // Exception wraps msg in s"Format Specifier '$msg'"
+        throw new MissingFormatArgumentException(msg)
+      }
+      args.next()
+    }
+
+    val pables = mutable.ListBuffer.empty[Printable]
+    var str = ""
+    var percent = false
+    for ((c, i) <- fmt.zipWithIndex) {
+      if (percent) {
+        val arg = c match {
+          case FirrtlFormat(x) => FirrtlFormat(x.toString, getArg(i))
+          case 'n' => Name(getArg(i))
+          case 'N' => FullName(getArg(i))
+          case '%' => Percent
+          case x =>
+            val msg = s"Illegal format specifier '$x'!\n" + errorMsg(i)
+            throw new UnknownFormatConversionException(msg)
+        }
+        pables += PString(str dropRight 1) // remove format %
+        pables += arg
+        str = ""
+        percent = false
+      } else {
+        str += c
+        percent = c == '%'
+      }
+    }
+    if (percent) {
+      val msg = s"Trailing %\n" + errorMsg(fmt.size - 1)
+      throw new UnknownFormatConversionException(msg)
+    }
+    require(!args.hasNext,
+      s"Too many arguments! More format specifier(s) expected!\n" +
+      errorMsg(fmt.size))
+
+    pables += PString(str)
+    Printables(pables)
+  }
+}
+
+case class Printables(pables: Iterable[Printable]) extends Printable {
+  require(pables.hasDefiniteSize, "Infinite-sized iterables are not supported!")
+  final def unpack: (String, Iterable[String]) = {
+    val (fmts, args) = pables.map(_.unpack).unzip
+    (fmts.mkString, args.flatten)
+  }
+}
+/** Wrapper for printing Scala Strings */
+case class PString(str: String) extends Printable {
+  final def unpack: (String, Iterable[String]) =
+    (str replaceAll ("%", "%%"), List.empty)
+}
+/** Superclass for Firrtl format specifiers for Bits */
+sealed abstract class FirrtlFormat(specifier: Char) extends Printable {
+  def bits: Bits
+  def unpack: (String, Iterable[String]) = {
+    val id = if (bits.isLit) bits.ref.name else bits.instanceName
+    (s"%$specifier", List(id))
+  }
+}
+object FirrtlFormat {
+  final val legalSpecifiers = List('d', 'x', 'b', 'c')
+
+  def unapply(x: Char): Option[Char] =
+    Option(x) filter (x => legalSpecifiers contains x)
+
+  /** Helper for constructing Firrtl Formats
+    * Accepts data to simplify pack
+    */
+  def apply(specifier: String, data: Data): FirrtlFormat = {
+    val bits = data match {
+      case b: Bits => b
+      case d => throw new Exception(s"Trying to construct FirrtlFormat with non-bits $d!")
+    }
+    specifier match {
+      case "d" => Decimal(bits)
+      case "x" => Hexadecimal(bits)
+      case "b" => Binary(bits)
+      case "c" => Character(bits)
+      case c => throw new Exception(s"Illegal format specifier '$c'!")
+    }
+  }
+}
+/** Format bits as Decimal */
+case class Decimal(bits: Bits) extends FirrtlFormat('d')
+/** Format bits as Hexidecimal */
+case class Hexadecimal(bits: Bits) extends FirrtlFormat('x')
+/** Format bits as Binary */
+case class Binary(bits: Bits) extends FirrtlFormat('b')
+/** Format bits as Character */
+case class Character(bits: Bits) extends FirrtlFormat('c')
+/** Put innermost name (eg. field of bundle) */
+case class Name(data: Data) extends Printable {
+  final def unpack: (String, Iterable[String]) = (data.ref.name, List.empty)
+}
+/** Put full name within parent namespace (eg. bundleName.field) */
+case class FullName(hasId: HasId) extends Printable {
+  final def unpack: (String, Iterable[String]) = (hasId.instanceName, List.empty)
+}
+/** Represents escaped percents */
+case object Percent extends Printable {
+  final def unpack: (String, Iterable[String]) = ("%%", List.empty)
+}

--- a/chiselFrontend/src/main/scala/chisel3/core/Printf.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Printf.scala
@@ -10,6 +10,24 @@ import chisel3.internal.firrtl._
 import chisel3.internal.sourceinfo.SourceInfo
 
 object printf { // scalastyle:ignore object.name
+  /** Helper for packing escape characters */
+  private[chisel3] def format(formatIn: String): String = {
+    require(formatIn forall (c => c.toInt > 0 && c.toInt < 128),
+      "format strings must comprise non-null ASCII values")
+    def escaped(x: Char) = {
+      require(x.toInt >= 0)
+      if (x == '"' || x == '\\') {
+        s"\\${x}"
+      } else if (x == '\n') {
+        "\\n"
+      } else {
+        require(x.toInt >= 32) // TODO \xNN once FIRRTL issue #59 is resolved
+        x
+      }
+    }
+    formatIn map escaped mkString ""
+  }
+
   /** Prints a message in simulation.
     *
     * Does not fire when in reset (defined as the encapsulating Module's
@@ -23,14 +41,30 @@ object printf { // scalastyle:ignore object.name
     * @param fmt printf format string
     * @param data format string varargs containing data to print
     */
-  def apply(fmt: String, data: Bits*)(implicit sourceInfo: SourceInfo) {
-    when (!(Builder.dynamicContext.currentModule.get.reset)) {
-      printfWithoutReset(fmt, data:_*)
+  def apply(fmt: String, data: Bits*)(implicit sourceInfo: SourceInfo): Unit =
+    apply(Printable.pack(fmt, data:_*))
+  /** Prints a message in simulation.
+    *
+    * Does not fire when in reset (defined as the encapsulating Module's
+    * reset). If your definition of reset is not the encapsulating Module's
+    * reset, you will need to gate this externally.
+    *
+    * May be called outside of a Module (like defined in a function), so
+    * functions using printf make the standard Module assumptions (single clock
+    * and single reset).
+    *
+    * @param pable [[Printable]] to print
+    */
+  def apply(pable: Printable)(implicit sourceInfo: SourceInfo): Unit = {
+    when (!Builder.dynamicContext.currentModule.get.reset) {
+      printfWithoutReset(pable)
     }
   }
 
-  private[core] def printfWithoutReset(fmt: String, data: Bits*)(implicit sourceInfo: SourceInfo) {
+  private[chisel3] def printfWithoutReset(pable: Printable)(implicit sourceInfo: SourceInfo): Unit = {
     val clock = Builder.dynamicContext.currentModule.get.clock
-    pushCommand(Printf(sourceInfo, Node(clock), fmt, data.map((d: Bits) => d.ref)))
+    pushCommand(Printf(sourceInfo, Node(clock), pable))
   }
+  private[chisel3] def printfWithoutReset(fmt: String, data: Bits*)(implicit sourceInfo: SourceInfo): Unit =
+    printfWithoutReset(Printable.pack(fmt, data:_*))
 }

--- a/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -169,22 +169,6 @@ case class ConnectInit(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Comm
 case class Stop(sourceInfo: SourceInfo, clk: Arg, ret: Int) extends Command
 case class Component(id: Module, name: String, ports: Seq[Port], commands: Seq[Command]) extends Arg
 case class Port(id: Data, dir: Direction)
-case class Printf(sourceInfo: SourceInfo, clk: Arg, formatIn: String, ids: Seq[Arg]) extends Command {
-  require(formatIn.forall(c => c.toInt > 0 && c.toInt < 128), "format strings must comprise non-null ASCII values")
-  def format: String = {
-    def escaped(x: Char) = {
-      require(x.toInt >= 0)
-      if (x == '"' || x == '\\') {
-        s"\\${x}"
-      } else if (x == '\n') {
-        "\\n"
-      } else {
-        require(x.toInt >= 32) // TODO \xNN once FIRRTL issue #59 is resolved
-        x
-      }
-    }
-    formatIn.map(escaped _).mkString
-  }
-}
+case class Printf(sourceInfo: SourceInfo, clk: Arg, pable: Printable) extends Command
 
 case class Circuit(name: String, components: Seq[Component])

--- a/src/main/scala/chisel3/internal/firrtl/Emitter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Emitter.scala
@@ -25,7 +25,11 @@ private class Emitter(circuit: Circuit) {
       case e: Connect => s"${e.loc.fullName(ctx)} <= ${e.exp.fullName(ctx)}"
       case e: BulkConnect => s"${e.loc1.fullName(ctx)} <- ${e.loc2.fullName(ctx)}"
       case e: Stop => s"stop(${e.clk.fullName(ctx)}, UInt<1>(1), ${e.ret})"
-      case e: Printf => s"""printf(${e.clk.fullName(ctx)}, UInt<1>(1), "${e.format}"${e.ids.map(_.fullName(ctx)).fold(""){_ + ", " + _}})"""
+      case e: Printf =>
+        val (fmt, args) = e.pable.unpack
+        val printfArgs = Seq(e.clk.fullName(ctx), "UInt<1>(1)",
+          "\"" + printf.format(fmt) + "\"") ++ args
+        printfArgs mkString ("printf(", ", ", ")")
       case e: DefInvalid => s"${e.arg.fullName(ctx)} is invalid"
       case e: DefInstance => s"inst ${e.name} of ${e.id.modName}"
       case w: WhenBegin =>

--- a/src/test/scala/chiselTests/PrintableSpec.scala
+++ b/src/test/scala/chiselTests/PrintableSpec.scala
@@ -1,0 +1,162 @@
+package chiselTests
+
+import org.scalatest.{FlatSpec, Matchers}
+import scala.collection.mutable
+
+import chisel3._
+import chisel3.testers.BasicTester
+
+/* Printable Tests */
+class PrintableSpec extends FlatSpec with Matchers {
+  private val PrintfRegex = """\s*printf\((.*)\).*""".r
+  // This regex is brittle, it relies on the first two arguments of the printf
+  // not containing quotes, problematic if Chisel were to emit UInt<1>("h01")
+  // instead of the current UInt<1>(1) for the enable signal
+  private val StringRegex = """([^"]*)"(.*?)"(.*)""".r
+  private case class Printf(str: String, args: Seq[String])
+  private def getPrintfs(firrtl: String): Seq[Printf] = {
+    def processArgs(str: String): Seq[String] =
+      str split "," map (_.trim) filter (_.nonEmpty)
+    def processBody(str: String): (String, Seq[String]) = {
+      str match {
+        case StringRegex(_, fmt, args) =>
+          (fmt, processArgs(args))
+        case _ => fail(s"Regex to process Printf should work on $str!")
+      }
+    }
+
+    firrtl split "\n" collect {
+      case PrintfRegex(matched) =>
+        val (str, args) = processBody(matched)
+        Printf(str, args)
+    }
+  }
+
+  behavior of "Printable & Custom Interpolator"
+
+  it should "pass exact strings through" in {
+    class MyModule extends BasicTester {
+      printf(p"An exact string")
+    }
+    val firrtl = Driver.emit(() => new MyModule)
+    getPrintfs(firrtl) match {
+      case Seq(Printf("An exact string", Seq())) =>
+      case e => fail()
+    }
+  }
+  it should "handle Printable and String concatination" in {
+    class MyModule extends BasicTester {
+      printf(p"First " + PString("Second ") + "Third")
+    }
+    val firrtl = Driver.emit(() => new MyModule)
+    getPrintfs(firrtl) match {
+      case Seq(Printf("First Second Third", Seq())) =>
+      case e => fail()
+    }
+  }
+  it should "call toString on non-Printable objects" in {
+    class MyModule extends BasicTester {
+      val myInt = 1234
+      printf(p"myInt = $myInt")
+    }
+    val firrtl = Driver.emit(() => new MyModule)
+    getPrintfs(firrtl) match {
+      case Seq(Printf("myInt = 1234", Seq())) =>
+      case e => fail()
+    }
+  }
+  it should "generate proper printf for simple Decimal printing" in {
+    class MyModule extends BasicTester {
+      val myWire = Wire(init = UInt(1234))
+      printf(p"myWire = ${Decimal(myWire)}")
+    }
+    val firrtl = Driver.emit(() => new MyModule)
+    getPrintfs(firrtl) match {
+      case Seq(Printf("myWire = %d", Seq("myWire"))) =>
+      case e => fail()
+    }
+  }
+  it should "handle printing literals" in {
+    class MyModule extends BasicTester {
+      printf(Decimal(UInt(10, 32)))
+    }
+    val firrtl = Driver.emit(() => new MyModule)
+    getPrintfs(firrtl) match {
+      case Seq(Printf("%d", Seq(lit))) =>
+        assert(lit contains "UInt<32>")
+      case e => fail()
+    }
+  }
+  it should "correctly escape percent" in {
+    class MyModule extends BasicTester {
+      printf(p"%")
+    }
+    val firrtl = Driver.emit(() => new MyModule)
+    getPrintfs(firrtl) match {
+      case Seq(Printf("%%", Seq())) =>
+      case e => fail()
+    }
+  }
+  it should "support names of circuit elements and the current module" in {
+    class MyBundle extends Bundle {
+      val foo = UInt(width = 32)
+      override def cloneType = (new MyBundle).asInstanceOf[this.type]
+    }
+    class MyModule extends BasicTester {
+      override def desiredName = "MyModule"
+      val myWire = Wire(new MyBundle)
+      printf(p"${Name(myWire.foo)}")
+      printf(p"${FullName(myWire.foo)}")
+      printf(p"${FullName(this)}")
+    }
+    val firrtl = Driver.emit(() => new MyModule)
+    getPrintfs(firrtl) match {
+      case Seq(Printf("foo", Seq()),
+               Printf("myWire.foo", Seq()),
+               Printf("MyModule", Seq())) =>
+      case e => fail()
+    }
+  }
+  it should "print UInts and SInts as Decimal by default" in {
+    class MyModule extends BasicTester {
+      val myUInt = Wire(init = UInt(0))
+      val mySInt = Wire(init = SInt(-1))
+      printf(p"$myUInt & $mySInt")
+    }
+    val firrtl = Driver.emit(() => new MyModule)
+    getPrintfs(firrtl) match {
+      case Seq(Printf("%d & %d", Seq("myUInt", "mySInt"))) =>
+      case e => fail()
+    }
+  }
+  it should "print Vecs like Scala Seqs by default" in {
+    class MyModule extends BasicTester {
+      val myVec = Wire(Vec(4, UInt(width = 32)))
+      myVec foreach (_ := UInt(0))
+      printf(p"$myVec")
+    }
+    val firrtl = Driver.emit(() => new MyModule)
+    getPrintfs(firrtl) match {
+      case Seq(Printf("Vec(%d, %d, %d, %d)",
+               Seq("myVec[0]", "myVec[1]", "myVec[2]", "myVec[3]"))) =>
+      case e => fail()
+    }
+  }
+  it should "print Bundles like Scala Maps by default" in {
+    class MyModule extends BasicTester {
+      val myBun = Wire(new Bundle {
+        val foo = UInt(width = 32)
+        val bar = UInt(width = 32)
+      })
+      myBun.foo := UInt(0)
+      myBun.bar := UInt(0)
+      printf(p"$myBun")
+    }
+    val firrtl = Driver.emit(() => new MyModule)
+    getPrintfs(firrtl) match {
+      case Seq(Printf("Bundle(foo -> %d, bar -> %d)",
+               Seq("myBun.foo", "myBun.bar"))) =>
+      case e => fail()
+    }
+  }
+}

--- a/src/test/scala/chiselTests/Printf.scala
+++ b/src/test/scala/chiselTests/Printf.scala
@@ -4,6 +4,7 @@ package chiselTests
 
 import org.scalatest._
 import chisel3._
+import chisel3.util._
 import chisel3.testers.BasicTester
 
 class SinglePrintfTester() extends BasicTester {
@@ -24,6 +25,11 @@ class MultiPrintfTester() extends BasicTester {
   stop()
 }
 
+class ASCIIPrintableTester extends BasicTester {
+  printf(PString((0x20 to 0x7e) map (_.toChar) mkString ""))
+  stop()
+}
+
 class PrintfSpec extends ChiselFlatSpec {
   "A printf with a single argument" should "run" in {
     assertTesterPasses { new SinglePrintfTester }
@@ -33,5 +39,8 @@ class PrintfSpec extends ChiselFlatSpec {
   }
   "A printf with ASCII characters 1-127" should "run" in {
     assertTesterPasses { new ASCIIPrintfTester }
+  }
+  "A printf with Printable ASCII characters 1-127" should "run" in {
+    assertTesterPasses { new ASCIIPrintableTester }
   }
 }


### PR DESCRIPTION
Printable is a new type that changes how printing of Chisel types is represented
It uses an ordered collection rather than a format string and specifiers
Main Features:
 - Custom String Interpolator for Scala-like printf
 - String-like manipulation of "hardware strings" for custom pretty-printing
 - Default pretty-printing for Chisel data types

A few notes and questions:
- This does *not* remove the old printf functionality
- This partially resolves @ccelio's need for hardware strings, it allows for strings to be constructed naturally although it will emit the full string for each printf that results
- There is a bit of an inconsistency between the new naming API and this which uses FullName and Name. FullName corresponds to instanceName, and Name is just the local name of a field (eg. within a bundle)
- Should this actually be a part of Chisel? Here are the reasons it's not currently a library
  - want the ability to put names of Chisel things in resulting printfs (useful for logging)
  - want default pretty-printing of Chisel types (Vec prints like Scala Seq, Bundle prints like Scala map)
- It is a bit cumbersome to type `p"blah blah Decimal(myWire) blah blah"` so I suggest that if this is merged we come up with shorthand. Decimal, Hexadecimal, Binary, and Character are just the underlying case class names, we could create other ways to create those Printables