### PR TITLE
Add IrrevocableIO alternative to DecoupledIO

### DIFF
--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -25,7 +25,8 @@ object Decoupled {
 }
 
 /** An extension of DecoupledIO that promises to not change the value of 'bits'
-  * after a cycle where 'valid' is high and 'ready' is low.
+  * after a cycle where 'valid' is high and 'ready' is low, and that once 
+  * 'valid' is raised it will never be lowered until after 'ready' has also been raised.
   */
 class IrrevocableIO[+T <: Data](gen: T) extends DecoupledIO[T](gen)
 


### PR DESCRIPTION
… that promises not to change the contents of .bits on a cycle after .valid is high and .ready is low. This is useful for detecting whether queues have been correctly inserted in front of modules that require these additional semantics.