### PR TITLE
Driver: Check the simulation exit code

### DIFF
--- a/src/main/scala/Chisel/Driver.scala
+++ b/src/main/scala/Chisel/Driver.scala
@@ -93,7 +93,9 @@ trait BackendCompilationUtilities {
         triggered = triggered || line.contains(assertionMsg)
         System.out.println(line)
       })
-    triggered
+    // Fail if a line contained an assertion or if we get a non-zero
+    // exit code
+    triggered || e != 0
   }
 
   def executeExpectingSuccess(prefix: String, dir: File): Boolean = {


### PR DESCRIPTION
Fail the test if the exit code of the simulation is non-zero.

Simulation timeouts return a non-zero exit code, so after this commit
tests that time out will be correctly reported as failures.