### PR TITLE
remove trailing whitespace for annotations

### DIFF
--- a/src/main/scala/chisel3/internal/firrtl/Emitter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Emitter.scala
@@ -40,7 +40,7 @@ private class Emitter(circuit: Circuit) {
         s"skip"
     }
     e.sourceInfo match {
-      case SourceLine(filename, line, col) => s"${firrtlLine} @[${filename} ${line}:${col}] "
+      case SourceLine(filename, line, col) => s"${firrtlLine} @[${filename} ${line}:${col}]"
       case _: NoSourceInfo => firrtlLine
     }
   }


### PR DESCRIPTION
Is this a typo, or is there a reason one would want a space following the source annotations?