### PR TITLE
Add Cookbook tests

### DIFF
--- a/src/test/scala/cookbook/Bundle2UInt.scala
+++ b/src/test/scala/cookbook/Bundle2UInt.scala
@@ -1,0 +1,31 @@
+// See LICENSE for license details.
+
+package cookbook
+
+import chisel3._
+
+/* ### How do I create a UInt from an instance of a Bundle?
+ *
+ * Call asUInt on the Bundle instance
+ */
+class Bundle2UInt extends CookbookTester(0) {
+  // Example
+  class MyBundle extends Bundle {
+    val foo = UInt(width = 4)
+    val bar = UInt(width = 4)
+  }
+  val bundle = Wire(new MyBundle)
+  bundle.foo := UInt(0xc)
+  bundle.bar := UInt(0x3)
+  val uint = bundle.asUInt
+  printf(p"$uint") // 195
+
+  // Test
+  assert(uint === UInt(0xc3))
+}
+
+class Bundle2UIntSpec  extends CookbookSpec {
+  "Bundle2UInt" should "work" in {
+    assertTesterPasses { new Bundle2UInt }
+  }
+}

--- a/src/test/scala/cookbook/CookbookSpec.scala
+++ b/src/test/scala/cookbook/CookbookSpec.scala
@@ -1,0 +1,25 @@
+// See LICENSE for license details.
+
+package cookbook
+
+import chisel3._
+import chisel3.util._
+import chisel3.testers.BasicTester
+
+import chiselTests.ChiselFlatSpec
+
+/** Tester for concise cookbook tests
+  *
+  * Provides a length of test after which the test will pass 
+  */
+abstract class CookbookTester(length: Int) extends BasicTester {
+  require(length >= 0, "Simulation length must be non-negative!")
+
+  // No IO allowed, cookbook tests must be self-contained
+  override final val io = new Bundle { }
+
+  val (cycle, done) = Counter(Bool(true), length)
+  when (done) { stop() }
+}
+
+abstract class CookbookSpec extends ChiselFlatSpec

--- a/src/test/scala/cookbook/UInt2Bundle.scala
+++ b/src/test/scala/cookbook/UInt2Bundle.scala
@@ -1,0 +1,30 @@
+// See LICENSE for license details.
+
+package cookbook
+
+import chisel3._
+
+/* ### How do I create a Bundle from a UInt?
+ *
+ * On an instance of the Bundle, call the method fromBits with the UInt as the argument
+ */
+class UInt2Bundle extends CookbookTester(0) {
+  // Example
+  class MyBundle extends Bundle {
+    val foo = UInt(width = 4)
+    val bar = UInt(width = 4)
+  }
+  val uint = UInt(0xb4)
+  val bundle = (new MyBundle).fromBits(uint)
+  printf(p"$bundle") // Bundle(foo -> 11, bar -> 4)
+
+  // Test
+  assert(bundle.foo === UInt(0xb))
+  assert(bundle.bar === UInt(0x4))
+}
+
+class UInt2BundleSpec extends CookbookSpec {
+  "UInt2Bundle" should "work" in {
+    assertTesterPasses { new UInt2Bundle }
+  }
+}

--- a/src/test/scala/cookbook/UInt2VecOfBool.scala
+++ b/src/test/scala/cookbook/UInt2VecOfBool.scala
@@ -1,0 +1,29 @@
+// See LICENSE for license details.
+
+package cookbook
+
+import chisel3._
+
+/* ### How do I create a Vec of Bools from a UInt?
+ *
+ * Use the builtin function [[chisel3.core.Bits.toBools]] to create a Scala Seq of Bool,
+ * then wrap the resulting Seq in Vec(...)
+ */
+class UInt2VecOfBool extends CookbookTester(0) {
+  // Example
+  val uint = UInt(0xc)
+  val vec = Vec(uint.toBools)
+  printf(p"$vec") // Vec(0, 0, 1, 1)
+
+  // Test
+  assert(vec(0) === Bool(false))
+  assert(vec(1) === Bool(false))
+  assert(vec(2) === Bool(true))
+  assert(vec(3) === Bool(true))
+}
+
+class UInt2VecOfBoolSpec extends CookbookSpec {
+  "UInt2VecOfBool" should "work" in {
+    assertTesterPasses { new UInt2VecOfBool }
+  }
+}

--- a/src/test/scala/cookbook/VecOfBool2UInt.scala
+++ b/src/test/scala/cookbook/VecOfBool2UInt.scala
@@ -1,0 +1,28 @@
+// See LICENSE for license details.
+
+package cookbook
+
+import chisel3._
+
+/* ### How do I create a UInt from a Vec of Bool?
+ *
+ * Use the builtin function asUInt
+ */
+class VecOfBool2UInt extends CookbookTester(0) {
+  // Example
+  val vec = Vec(Bool(true), Bool(false), Bool(true), Bool(true))
+  val uint = vec.asUInt
+  printf(p"$uint") // 13
+  
+  /* Test
+   *
+   * (remember leftmost Bool in Vec is low order bit)
+   */
+  assert(UInt(0xd) === uint)
+}
+
+class VecOfBool2UIntSpec  extends CookbookSpec {
+  "VecOfBool2UInt" should "work" in {
+    assertTesterPasses { new VecOfBool2UInt }
+  }
+}


### PR DESCRIPTION
These tests are intended to be the examples in the Chisel3 Wiki Cookbook.

The primary idea is that the Cookbook examples should always be working so I want to generate the actual documentation on the Wiki from these examples. I am looking into tools to help do this, but haven't been able to get one working yet.

https://github.com/ucb-bar/chisel3/wiki/Cookbook