### PR TITLE
Make implicit clock name consistent

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -94,7 +94,7 @@ extends HasId {
   private[chisel3] def addId(d: HasId) { _ids += d }
 
   private[core] def ports: Seq[(String,Data)] = Vector(
-    ("clk", clock), ("reset", reset), ("io", io)
+    ("clock", clock), ("reset", reset), ("io", io)
   )
 
   private[core] def computePorts = for((name, port) <- ports) yield {

--- a/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -166,9 +166,9 @@ case class WhenEnd(sourceInfo: SourceInfo) extends Command
 case class Connect(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
 case class BulkConnect(sourceInfo: SourceInfo, loc1: Node, loc2: Node) extends Command
 case class ConnectInit(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
-case class Stop(sourceInfo: SourceInfo, clk: Arg, ret: Int) extends Command
+case class Stop(sourceInfo: SourceInfo, clock: Arg, ret: Int) extends Command
 case class Component(id: Module, name: String, ports: Seq[Port], commands: Seq[Command]) extends Arg
 case class Port(id: Data, dir: Direction)
-case class Printf(sourceInfo: SourceInfo, clk: Arg, pable: Printable) extends Command
+case class Printf(sourceInfo: SourceInfo, clock: Arg, pable: Printable) extends Command
 
 case class Circuit(name: String, components: Seq[Component])

--- a/src/main/resources/top.cpp
+++ b/src/main/resources/top.cpp
@@ -44,10 +44,10 @@ int main(int argc, char** argv) {
       top->reset = 0;   // Deassert reset
     }
     if ((main_time % 10) == 1) {
-      top->clk = 1;       // Toggle clock
+      top->clock = 1;       // Toggle clock
     }
     if ((main_time % 10) == 6) {
-      top->clk = 0;
+      top->clock = 0;
     }
     top->eval();               // Evaluate model
 #if VM_TRACE
@@ -69,10 +69,10 @@ int main(int argc, char** argv) {
   vluint64_t end_time = main_time + 100;
   while (main_time < end_time) {
     if ((main_time % 10) == 1) {
-      top->clk = 1;       // Toggle clock
+      top->clock = 1;       // Toggle clock
     }
     if ((main_time % 10) == 6) {
-      top->clk = 0;
+      top->clock = 0;
     }
     top->eval();               // Evaluate model
 #if VM_TRACE

--- a/src/main/scala/chisel3/internal/firrtl/Emitter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Emitter.scala
@@ -24,10 +24,10 @@ private class Emitter(circuit: Circuit) {
       case e: DefMemPort[_] => s"${e.dir} mport ${e.name} = ${e.source.fullName(ctx)}[${e.index.fullName(ctx)}], ${e.clock.fullName(ctx)}"
       case e: Connect => s"${e.loc.fullName(ctx)} <= ${e.exp.fullName(ctx)}"
       case e: BulkConnect => s"${e.loc1.fullName(ctx)} <- ${e.loc2.fullName(ctx)}"
-      case e: Stop => s"stop(${e.clk.fullName(ctx)}, UInt<1>(1), ${e.ret})"
+      case e: Stop => s"stop(${e.clock.fullName(ctx)}, UInt<1>(1), ${e.ret})"
       case e: Printf =>
         val (fmt, args) = e.pable.unpack(ctx)
-        val printfArgs = Seq(e.clk.fullName(ctx), "UInt<1>(1)",
+        val printfArgs = Seq(e.clock.fullName(ctx), "UInt<1>(1)",
           "\"" + printf.format(fmt) + "\"") ++ args
         printfArgs mkString ("printf(", ", ", ")")
       case e: DefInvalid => s"${e.arg.fullName(ctx)} is invalid"


### PR DESCRIPTION
In the Chisel frontend, the implicit clock is named clock, but in the
generated FIRRTL, it is named clk.  There is no reason for this
discrepancy, and yet fixing it is painful, as it will break test harnesses.
Better to take the pain now than later.

Resolves #258.