### PR TITLE
Expose FIRRTL asClock construct

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -699,6 +699,11 @@ sealed class Bool(dir: Direction, lit: Option[ULit] = None) extends UInt(dir, Wi
   def && (that: Bool): Bool = macro SourceInfoTransform.thatArg
 
   def do_&& (that: Bool)(implicit sourceInfo: SourceInfo): Bool = this & that
+
+  /** Reinterprets this Bool as a Clock.  */
+  def asClock(): Clock = macro SourceInfoTransform.noArg
+
+  def do_asClock(implicit sourceInfo: SourceInfo): Clock = pushOp(DefPrim(sourceInfo, Clock(), AsClockOp, ref))
 }
 
 object Bool {

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -5,9 +5,10 @@ package chisel3.core
 import scala.language.experimental.macros
 
 import chisel3.internal._
-import chisel3.internal.Builder.pushCommand
+import chisel3.internal.Builder.{pushCommand, pushOp}
 import chisel3.internal.firrtl._
 import chisel3.internal.sourceinfo.{SourceInfo, DeprecatedSourceInfo, UnlocatableSourceInfo, WireTransform, SourceInfoTransform}
+import chisel3.internal.firrtl.PrimOp.AsUIntOp
 
 sealed abstract class Direction(name: String) {
   override def toString: String = name
@@ -177,4 +178,6 @@ sealed class Clock(dirArg: Direction) extends Element(dirArg, Width(1)) {
 
   /** Not really supported */
   def toPrintable: Printable = PString("CLOCK")
+
+  override def do_asUInt(implicit sourceInfo: SourceInfo): UInt = pushOp(DefPrim(sourceInfo, UInt(this.width), AsUIntOp, ref))
 }

--- a/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -42,6 +42,7 @@ object PrimOp {
   val ConvertOp = PrimOp("cvt")
   val AsUIntOp = PrimOp("asUInt")
   val AsSIntOp = PrimOp("asSInt")
+  val AsClockOp = PrimOp("asClock")
 }
 
 abstract class Arg {

--- a/src/test/scala/chiselTests/Clock.scala
+++ b/src/test/scala/chiselTests/Clock.scala
@@ -1,0 +1,22 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import org.scalatest._
+import org.scalatest.prop._
+
+import chisel3._
+import chisel3.testers.BasicTester
+import chisel3.util._
+
+class ClockAsUIntTester extends BasicTester {
+  assert(Bool(true).asClock.asUInt === UInt(1))
+  stop()
+}
+
+
+class ClockSpec extends ChiselPropSpec {
+  property("Bool.asClock.asUInt should pass a signal through unaltered") {
+    assertTesterPasses { new ClockAsUIntTester }
+  }
+}


### PR DESCRIPTION
This allows people to write clock-management circuitry in Chisel, rather
than mandating the use of BlackBoxes.