### PR TITLE
Add support for parameterized BlackBoxes

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/BlackBox.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/BlackBox.scala
@@ -3,10 +3,19 @@
 package chisel3.core
 
 import chisel3.internal.Builder.pushCommand
-import chisel3.internal.firrtl.{ModuleIO, DefInvalid}
+import chisel3.internal.firrtl._
+import chisel3.internal.throwException
 import chisel3.internal.sourceinfo.SourceInfo
 // TODO: remove this once we have CompileOptions threaded through the macro system.
 import chisel3.core.ExplicitCompileOptions.NotStrict
+
+/** Parameters for BlackBoxes */
+sealed abstract class Param
+case class IntParam(value: BigInt) extends Param
+case class DoubleParam(value: Double) extends Param
+case class StringParam(value: String) extends Param
+/** Unquoted String */
+case class RawParam(value: String) extends Param
 
 /** Defines a black box, which is a module that can be referenced from within
   * Chisel, but is not defined in the emitted Verilog. Useful for connecting
@@ -16,12 +25,9 @@ import chisel3.core.ExplicitCompileOptions.NotStrict
   * {{{
   * ... to be written once a spec is finalized ...
   * }}}
+  * @note The parameters API is experimental and may change
   */
-// REVIEW TODO: make Verilog parameters part of the constructor interface?
-abstract class BlackBox extends Module {
-  // Don't bother taking override_clock|reset, clock/reset locked out anyway
-  // TODO: actually implement this.
-  def setVerilogParameters(s: String): Unit = {}
+abstract class BlackBox(val params: Map[String, Param] = Map.empty[String, Param]) extends Module {
 
   // The body of a BlackBox is empty, the real logic happens in firrtl/Emitter.scala
   // Bypass standard clock, reset, io port declaration by flattening io

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -41,8 +41,16 @@ object Module {
                      sourceInfo.makeMessage(" See " + _))
     }
     Builder.currentModule = parent // Back to parent!
+
     val ports = m.computePorts
-    val component = Component(m, m.name, ports, m._commands)
+    // Blackbox inherits from Module so we have to match on it first TODO fix
+    val component = m match {
+      case bb: BlackBox =>
+        DefBlackBox(bb, bb.name, ports, bb.params)
+      case mod: Module =>
+        mod._commands.prepend(DefInvalid(childSourceInfo, mod.io.ref)) // init module outputs
+        DefModule(mod, mod.name, ports, mod._commands)
+    }
     m._component = Some(component)
     Builder.components += component
     // Avoid referencing 'parent' in top module

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -181,7 +181,10 @@ private[chisel3] object Builder {
   // TODO(twigg): Ideally, binding checks and new bindings would all occur here
   // However, rest of frontend can't support this yet.
   def pushCommand[T <: Command](c: T): T = {
-    forcedModule._commands += c
+    forcedModule match {
+      case _: BlackBox => throwException("Cannot add hardware to a BlackBox")
+      case m => m._commands += c
+    }
     c
   }
   def pushOp[T <: Data](cmd: DefPrim[T]): T = {

--- a/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -215,8 +215,14 @@ case class Connect(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
 case class BulkConnect(sourceInfo: SourceInfo, loc1: Node, loc2: Node) extends Command
 case class ConnectInit(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
 case class Stop(sourceInfo: SourceInfo, clock: Arg, ret: Int) extends Command
-case class Component(id: Module, name: String, ports: Seq[Port], commands: Seq[Command]) extends Arg
 case class Port(id: Data, dir: Direction)
 case class Printf(sourceInfo: SourceInfo, clock: Arg, pable: Printable) extends Command
+abstract class Component extends Arg {
+  def id: Module
+  def name: String
+  def ports: Seq[Port]
+}
+case class DefModule(id: Module, name: String, ports: Seq[Port], commands: Seq[Command]) extends Component
+case class DefBlackBox(id: Module, name: String, ports: Seq[Port], params: Map[String, Param]) extends Component
 
 case class Circuit(name: String, components: Seq[Component])

--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -119,13 +119,13 @@ trait BackendCompilationUtilities {
         "-Wno-WIDTH",
         "-Wno-STMTDLY",
         "--trace",
-        "-O0",
+        "-O1",
         "--top-module", topModule,
         "+define+TOP_TYPE=V" + dutFile,
         s"+define+PRINTF_COND=!$topModule.reset",
         s"+define+STOP_COND=!$topModule.reset",
         "-CFLAGS",
-        s"""-Wno-undefined-bool-conversion -O0 -DTOP_TYPE=V$dutFile -include V$dutFile.h""",
+        s"""-Wno-undefined-bool-conversion -O1 -DTOP_TYPE=V$dutFile -include V$dutFile.h""",
         "-Mdir", dir.toString,
         "--exe", cppHarness.toString)
     System.out.println(s"${command.mkString(" ")}") // scalastyle:ignore regex

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -179,4 +179,28 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   }
   def getModulePorts(m: Module): Seq[Port] = m.getPorts
   def getFirrtlDirection(d: Data): Direction = chisel3.core.Data.getFirrtlDirection(d)
+
+  /** Package for experimental features, which may have their API changed, be removed, etc.
+    *
+    * Because its contents won't necessarily have the same level of stability and support as
+    * non-experimental, you must explicitly import this package to use its contents.
+    */
+  object experimental {
+    type Param = chisel3.core.Param
+    type IntParam = chisel3.core.IntParam
+    val IntParam = chisel3.core.IntParam
+    type DoubleParam = chisel3.core.DoubleParam
+    val DoubleParam = chisel3.core.DoubleParam
+    type StringParam = chisel3.core.StringParam
+    val StringParam = chisel3.core.StringParam
+    type RawParam = chisel3.core.RawParam
+    val RawParam = chisel3.core.RawParam
+
+    // Implicit conversions for BlackBox Parameters
+    implicit def fromIntToIntParam(x: Int): IntParam = IntParam(BigInt(x))
+    implicit def fromLongToIntParam(x: Long): IntParam = IntParam(BigInt(x))
+    implicit def fromBigIntToIntParam(x: BigInt): IntParam = IntParam(x)
+    implicit def fromDoubleToDoubleParam(x: Double): DoubleParam = DoubleParam(x)
+    implicit def fromStringToStringParam(x: String): StringParam = StringParam(x)
+  }
 }

--- a/src/test/resources/BlackBoxTest.v
+++ b/src/test/resources/BlackBoxTest.v
@@ -32,3 +32,28 @@ module BlackBoxConstant #(
 );
   assign out = VALUE;
 endmodule
+
+module BlackBoxStringParam #(
+  parameter string STRING = "zero"
+) (
+  output [31:0] out
+);
+  assign out = (STRING == "one" )? 1 :
+               (STRING == "two" )? 2 : 0;
+endmodule
+
+module BlackBoxRealParam #(
+  parameter real REAL = 0.0
+) (
+  output [63:0] out
+);
+  assign out = $realtobits(REAL);
+endmodule
+
+module BlackBoxTypeParam #(
+  parameter type T = bit
+) (
+  output T out
+);
+  assign out = 32'hdeadbeef;
+endmodule

--- a/src/test/scala/chiselTests/BlackBox.scala
+++ b/src/test/scala/chiselTests/BlackBox.scala
@@ -6,6 +6,7 @@ import java.io.File
 import org.scalatest._
 
 import chisel3._
+import chisel3.experimental._
 import chisel3.testers.BasicTester
 import chisel3.util._
 //import chisel3.core.ExplicitCompileOptions.Strict
@@ -84,27 +85,55 @@ class BlackBoxWithClockTester extends BasicTester {
   when(end) { stop() }
 }
 
-/*
-// Must determine how to handle parameterized Verilog
-class BlackBoxConstant(value: Int) extends BlackBox {
-  val io = IO(new Bundle() {
-    val out = Output(UInt(width=log2Up(value)))
+class BlackBoxConstant(value: Int) extends BlackBox(
+    Map("VALUE" -> value, "WIDTH" -> log2Up(value + 1))) {
+  require(value >= 0, "value must be a UInt!")
+  val io = IO(new Bundle {
+    val out = UInt(width = log2Up(value + 1)).asOutput
   })
-  override val name = s"#(WIDTH=${log2Up(value)},VALUE=$value) "
+}
+
+class BlackBoxStringParam(str: String) extends BlackBox(Map("STRING" -> str)) {
+  val io = IO(new Bundle {
+    val out = UInt(width = 32)
+  })
+}
+
+class BlackBoxRealParam(dbl: Double) extends BlackBox(Map("REAL" -> dbl)) {
+  val io = IO(new Bundle {
+    val out = UInt(width = 64)
+  })
+}
+
+class BlackBoxTypeParam(w: Int, raw: String) extends BlackBox(Map("T" -> RawParam(raw))) {
+  val io = IO(new Bundle {
+    val out = UInt(width = w)
+  })
 }
 
 class BlackBoxWithParamsTester extends BasicTester {
   val blackBoxOne  = Module(new BlackBoxConstant(1))
-  val blackBoxFour = Module(new BlackBoxConstant(4))
+  val blackBoxFour  = Module(new BlackBoxConstant(4))
+  val blackBoxStringParamOne = Module(new BlackBoxStringParam("one"))
+  val blackBoxStringParamTwo = Module(new BlackBoxStringParam("two"))
+  val blackBoxRealParamOne = Module(new BlackBoxRealParam(1.0))
+  val blackBoxRealParamNeg = Module(new BlackBoxRealParam(-1.0))
+  val blackBoxTypeParamBit = Module(new BlackBoxTypeParam(1, "bit"))
+  val blackBoxTypeParamWord = Module(new BlackBoxTypeParam(32, "bit [31:0]"))
 
   val (cycles, end) = Counter(Bool(true), 4)
 
   assert(blackBoxOne.io.out  === UInt(1))
   assert(blackBoxFour.io.out === UInt(4))
+  assert(blackBoxStringParamOne.io.out === UInt(1))
+  assert(blackBoxStringParamTwo.io.out === UInt(2))
+  assert(blackBoxRealParamOne.io.out === UInt(0x3ff0000000000000L))
+  assert(blackBoxRealParamNeg.io.out === UInt(BigInt("bff0000000000000", 16)))
+  assert(blackBoxTypeParamBit.io.out === UInt(1))
+  assert(blackBoxTypeParamWord.io.out === UInt("hdeadbeef", 32))
 
   when(end) { stop() }
 }
-*/
 
 class BlackBoxSpec extends ChiselFlatSpec {
   "A BlackBoxed inverter" should "work" in {
@@ -117,6 +146,10 @@ class BlackBoxSpec extends ChiselFlatSpec {
   }
   "A BlackBoxed register" should "work" in {
     assertTesterPasses({ new BlackBoxWithClockTester },
+        Seq("/BlackBoxTest.v"))
+  }
+  "BlackBoxes with parameters" should "work" in {
+    assertTesterPasses({ new BlackBoxWithParamsTester },
         Seq("/BlackBoxTest.v"))
   }
 }


### PR DESCRIPTION
Also restrict black boxes to not allow hardware inside of them since it was
being silently dropped anyway.

Resolves #289 

This PR obviously depends on ucb-bar/firrtl#314 in order to pass tests. Also, thanks to the new Firrtl feature where extmodules can overwrite their name, Chisel emits BlackBoxes that will always get their desired names.

The current API proposed by this PR is to make blackbox parameters be an argument to the BlackBox abstract class of type Map[String, Any] where Any is dynamically checked to be only be Int, Long, BigInt, Double, or String. This leads to the use in one of the test cases of:

``` scala
class BlackBoxConstant(params: Map[String, Any]) extends BlackBox(params) {
  val io = new Bundle {
    val out = UInt(width = params("WIDTH").asInstanceOf[Int]).asOutput
  }
}

class BlackBoxWithParamsTester extends BasicTester {
  val blackBoxOne  = Module(new BlackBoxConstant(Map("WIDTH" -> 1, "VALUE" -> 1)))
  val blackBoxFour  = Module(new BlackBoxConstant(Map("WIDTH" -> 3, "VALUE" -> 4)))
  ...
}
```

Alternatively, params could be a def overridden in the BlackBox body itself, then users could pass their parameters however they see fit and transform them to the Map[String, Any] in the body of the BlackBox.

I'm not the biggest fan of the above syntax and am certainly open to suggestions.
