### PR TITLE
Don't use firrtlDirection for direction checks - fix #298.

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -63,7 +63,7 @@ object Vec {
     val maxWidth = elts.map(_.width).reduce(_ max _)
     val vec = Wire(new Vec(t.cloneTypeWidth(maxWidth), elts.length))
     def doConnect(sink: T, source: T) = {
-      if (elts.head.flatten.exists(_.firrtlDirection != Direction.Unspecified)) {
+      if (elts.head.flatten.exists(_.dir != Direction.Unspecified)) {
         sink bulkConnect source
       } else {
         sink connect source

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -241,7 +241,9 @@ abstract class Data extends HasId {
 
   // firrtlDirection is the direction we report to firrtl.
   // It maintains the user-specified value (as opposed to the "actual" or applied/propagated value).
-  var firrtlDirection: Direction = Direction.Unspecified
+  // NOTE: This should only be used for emitting acceptable firrtl.
+  // The Element.dir should be used for any tests involving direction.
+  private var firrtlDirection: Direction = Direction.Unspecified
   /** Default pretty printing */
   def toPrintable: Printable
 }

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -84,7 +84,7 @@ object Decoupled
     * @note unsafe (and will error) on the producer (input) side of an IrrevocableIO
     */
   def apply[T <: Data](irr: IrrevocableIO[T]): DecoupledIO[T] = {
-    require(getFirrtlDirection(irr.bits) == OUTPUT, "Only safe to cast produced Irrevocable bits to Decoupled.")
+    require(irr.bits.flatten forall (_.dir == OUTPUT), "Only safe to cast produced Irrevocable bits to Decoupled.")
     val d = Wire(new DecoupledIO(irr.bits))
     d.bits := irr.bits
     d.valid := irr.valid
@@ -117,7 +117,7 @@ object Irrevocable
     * @note unsafe (and will error) on the consumer (output) side of an DecoupledIO
     */
   def apply[T <: Data](dec: DecoupledIO[T]): IrrevocableIO[T] = {
-    require(getFirrtlDirection(dec.bits) == INPUT, "Only safe to cast consumed Decoupled bits to Irrevocable.")
+    require(dec.bits.flatten forall (_.dir == INPUT), "Only safe to cast consumed Decoupled bits to Irrevocable.")
     val i = Wire(new IrrevocableIO(dec.bits))
     dec.bits := i.bits
     dec.valid := i.valid


### PR DESCRIPTION
`firrtlDirection` should only be used for emitting firrtl. Any checks on the actual direction should use the bound Direction `dir`.