### PR TITLE
Generate scaladoc for all subprojects.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,10 +6,18 @@ site.includeScaladoc()
 
 ghpages.settings
 
+import UnidocKeys._
+
+lazy val customUnidocSettings = unidocSettings ++ Seq (
+  doc in Compile := (doc in ScalaUnidoc).value,
+  target in unidoc in ScalaUnidoc := crossTarget.value / "api"
+)
+
 lazy val commonSettings = Seq (
   organization := "edu.berkeley.cs",
   version := "3.1-SNAPSHOT",
   git.remoteRepo := "git@github.com:ucb-bar/chisel3.git",
+  autoAPIMappings := true,
   scalaVersion := "2.11.7"
 )
 
@@ -94,18 +102,16 @@ lazy val chiselFrontend = (project in file("chiselFrontend")).
 
 lazy val chisel = (project in file(".")).
   settings(commonSettings: _*).
+  settings(customUnidocSettings: _*).
   settings(chiselSettings: _*).
   dependsOn(coreMacros).
   dependsOn(chiselFrontend).
   settings(
+    aggregate in doc := false,
     // Include macro classes, resources, and sources main jar.
     mappings in (Compile, packageBin) <++= mappings in (coreMacros, Compile, packageBin),
     mappings in (Compile, packageSrc) <++= mappings in (coreMacros, Compile, packageSrc),
     mappings in (Compile, packageBin) <++= mappings in (chiselFrontend, Compile, packageBin),
     mappings in (Compile, packageSrc) <++= mappings in (chiselFrontend, Compile, packageSrc)
-  )
-
-// This is ugly. There must be a better way.
-publish <<= (publish) dependsOn (publish in coreMacros, publish in chiselFrontend)
-
-publishLocal <<= (publishLocal) dependsOn (publishLocal in coreMacros, publishLocal in chiselFrontend)
+  ).
+  aggregate(coreMacros, chiselFrontend)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.2")
+
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")


### PR DESCRIPTION
Use aggregate to run project tasks in subprojects
Use sbt-unidoc to generate combined scaladoc for project and subprojects.