### PR TITLE
Add CompileOptions implicits to all Module constructors - fix #310.

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -54,9 +54,9 @@ abstract class Module(
 extends HasId {
   // _clock and _reset can be clock and reset in these 2ary constructors
   // once chisel2 compatibility issues are resolved
-  def this(_clock: Clock) = this(Option(_clock), None)
-  def this(_reset: Bool)  = this(None, Option(_reset))
-  def this(_clock: Clock, _reset: Bool) = this(Option(_clock), Option(_reset))
+  def this(_clock: Clock)(implicit moduleCompileOptions: CompileOptions) = this(Option(_clock), None)(moduleCompileOptions)
+  def this(_reset: Bool)(implicit moduleCompileOptions: CompileOptions)  = this(None, Option(_reset))(moduleCompileOptions)
+  def this(_clock: Clock, _reset: Bool)(implicit moduleCompileOptions: CompileOptions) = this(Option(_clock), Option(_reset))(moduleCompileOptions)
 
   // This function binds the iodef as a port in the hardware graph
   private[chisel3] def Port[T<:Data](iodef: T): iodef.type = {

--- a/src/test/scala/chiselTests/ModuleExplicitResetSpec.scala
+++ b/src/test/scala/chiselTests/ModuleExplicitResetSpec.scala
@@ -1,0 +1,38 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+class ModuleExplicitResetSpec extends ChiselFlatSpec  {
+
+  "A Module with an explicit reset in compatibility mode" should "elaborate" in {
+    import Chisel._
+    val myReset = Bool(true)
+    class ModuleExplicitReset(reset: Bool) extends Module(_reset = reset) {
+      val io = new Bundle {
+        val done = Bool(OUTPUT)
+      }
+
+      io.done := Bool(false)
+    }
+
+    elaborate {
+      new ModuleExplicitReset(myReset)
+    }
+  }
+
+  "A Module with an explicit reset in non-compatibility mode" should "elaborate" in {
+    import chisel3._
+    val myReset = Bool(true)
+    class ModuleExplicitReset(reset: Bool) extends Module(_reset = reset) {
+      val io = IO(new Bundle {
+        val done = Bool(OUTPUT)
+      })
+
+      io.done := Bool(false)
+    }
+
+    elaborate {
+      new ModuleExplicitReset(myReset)
+    }
+  }
+}


### PR DESCRIPTION
class Module has three other constructors (for variations on whether clock, reset, or both are explicitly provided). These also require an implicit CompileOptions parameter.