### PR TITLE
Implement a standardized execution scheme for chisel

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,8 @@ lazy val commonSettings = Seq (
   scalaVersion := "2.11.7"
 )
 
+val defaultVersions = Map("firrtl" -> "1.1-SNAPSHOT")
+
 lazy val chiselSettings = Seq (
   name := "chisel3",
 
@@ -62,19 +64,24 @@ lazy val chiselSettings = Seq (
     Resolver.sonatypeRepo("releases")
   ),
 
-  /* Bumping "com.novocode" % "junit-interface" % "0.11", causes DelayTest testSeqReadBundle to fail
-   *  in subtly disturbing ways on Linux (but not on Mac):
-   *  - some fields in the generated .h file are re-named,
-   *  - an additional field is added
-   *  - the generated .cpp file has additional differences:
-   *    - different temps in clock_lo
-   *    - missing assignments
-   *    - change of assignment order
-   *    - use of "Tx" vs. "Tx.values"
-   */
+  libraryDependencies ++= (Seq("firrtl").map {
+    dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) }),
+
+
+/* Bumping "com.novocode" % "junit-interface" % "0.11", causes DelayTest testSeqReadBundle to fail
+ *  in subtly disturbing ways on Linux (but not on Mac):
+ *  - some fields in the generated .h file are re-named,
+ *  - an additional field is added
+ *  - the generated .cpp file has additional differences:
+ *    - different temps in clock_lo
+ *    - missing assignments
+ *    - change of assignment order
+ *    - use of "Tx" vs. "Tx.values"
+ */
   libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.5" % "test",
   libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.12.4" % "test",
+  libraryDependencies += "com.github.scopt" %% "scopt" % "3.4.0",
 
   // Tests from other projects may still run concurrently.
   parallelExecution in Test := true,

--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -2,11 +2,32 @@
 
 package chisel3
 
+import scopt.OptionParser
+
 import scala.sys.process._
 import java.io._
 
-import internal._
 import internal.firrtl._
+import firrtl.{FirrtlExecutionFailure, FirrtlExecutionSuccess, FirrtlExecutionResult, FirrtlExecutionOptions}
+
+/**
+  * The Driver provides methods to invoke the chisel3 compiler and the firrtl compuiler.
+  * By default firrtl is automatically run after chisel.  The `ChiselExecutionOptions` extends
+  * 'FirrtlExecutionOptions' which extends 'CommonOptions'
+  * Like firrtl the Driver defines two execute methods, the first uses a ChiselExecutionOption
+  * @example
+  *          {{{
+  *          val options = new ChiselExecutionOptions()
+  *          options.runFirrtlCompiler = false
+  *          options.targetDir = "my-target-dir"
+  *          chisel3.Driver.execute(options, () => new Dut)
+  *          }}}
+  * or via command line arguments
+  * @example {{{
+  *          args = "--no-run-firrtl --target-dir my-target-dir".split(" +")
+  *          chisel3.execute(args, () => new DUT)
+  *          }}}
+  */
 
 trait BackendCompilationUtilities {
   /** Create a temporary directory with the prefix name. Exists here because it doesn't in Java 6.
@@ -31,6 +52,30 @@ trait BackendCompilationUtilities {
     vf
   }
 
+  /**
+    * like 'firrtlToVerilog' except it runs the process inside the same JVM
+    * @param prefix basename of the file
+    * @param dir    directory where file lives
+    * @return       true if compiler completed successfully
+    */
+  def compileFirrtlToVerilog(prefix: String, dir: File): Boolean = {
+    val firrtlExecutionOptions = new FirrtlExecutionOptions(
+      compilerName = "verilog")
+    firrtlExecutionOptions.topName = prefix
+    firrtlExecutionOptions.targetDirName = dir.getAbsolutePath
+
+    firrtl.Driver.execute(firrtlExecutionOptions) match {
+      case _: FirrtlExecutionSuccess => true
+      case _: FirrtlExecutionFailure => false
+    }
+  }
+
+  /**
+    * compule chirrtl to verilog by using a separate process
+    * @param prefix basename of the file
+    * @param dir    directory where file lives
+    * @return       true if compiler completed successfully
+    */
   def firrtlToVerilog(prefix: String, dir: File): ProcessBuilder = {
     Process(
       Seq("firrtl",
@@ -104,6 +149,54 @@ trait BackendCompilationUtilities {
   }
 }
 
+/**
+  * Options that are specific to chisel.
+  * @param runFirrtlCompiler when true just run chisel, when false run chisel then compile its output with firrtl
+  * @note this extends FirrtlExecutionOptions which extends CommonOptions providing easy access to down chain options
+  */
+class ChiselExecutionOptions(
+                              var runFirrtlCompiler: Boolean = true
+                              // var runFirrtlAsProcess: Boolean = false
+                            ) extends FirrtlExecutionOptions {
+
+  //TODO: provide support for running firrtl as separate process, could alternatively be controlled by external driver
+  //TODO: provide option for not saving chirrtl file, instead calling firrtl with in memory chirrtl
+  override def addOptions(parser: OptionParser[Unit]): Unit = {
+    super.addOptions(parser)
+
+    parser.note("chisel3 options")
+
+    parser.opt[Unit]("no-run-firrtl").abbr("chnrf").foreach(_ => runFirrtlCompiler = false)
+      .text("Stop after chisel emits chirrtl file")
+
+    // parser.opt[Unit]("run-firrtl-as-process").abbr("chrfap").foreach(_ => runFirrtlCompiler = false)
+    //  .text("Run firrtl as a separate process, not within same JVM as chisel")
+  }
+}
+
+/**
+  * This family provides return values from the chisel3 and possibly firrtl compile steps
+  */
+trait ChiselExecutionResult
+
+/**
+  *
+  * @param circuitOption  Optional circuit, has information like circuit name
+  * @param emitted            The emitted Chirrrl text
+  * @param firrtlResultOption Optional Firrtl result, @see ucb-bar/firrtl for details
+  */
+case class ChiselExecutionSucccess(
+                                  circuitOption: Option[Circuit],
+                                  emitted: String,
+                                  firrtlResultOption: Option[FirrtlExecutionResult]
+                                  ) extends ChiselExecutionResult
+
+/**
+  * Getting one of these indicates failure of some sort
+  * @param message  a clue perhaps will be provided in the here
+  */
+case class ChiselExecutionFailure(message: String) extends ChiselExecutionResult
+
 object Driver extends BackendCompilationUtilities {
 
   /** Elaborates the Module specified in the gen function into a Circuit
@@ -111,7 +204,7 @@ object Driver extends BackendCompilationUtilities {
     *  @param gen a function that creates a Module hierarchy
     *  @return the resulting Chisel IR in the form of a Circuit (TODO: Should be FIRRTL IR)
     */
-  def elaborate[T <: Module](gen: () => T): Circuit = Builder.build(Module(gen()))
+  def elaborate[T <: Module](gen: () => T): Circuit = internal.Builder.build(Module(gen()))
 
   def emit[T <: Module](gen: () => T): String = Emitter.emit(elaborate(gen))
 
@@ -135,4 +228,66 @@ object Driver extends BackendCompilationUtilities {
   }
 
   def targetDir(): String = { target_dir getOrElse new File(".").getCanonicalPath }
+
+  /**
+    * Run the chisel3 compiler and possibly the firrtl compiler with options specified
+    * @param chiselExecutionOptions The options specified
+    * @param dut                    The device under test
+    * @return                       An execution result with useful stuff, or failure with message
+    */
+  def execute(chiselExecutionOptions: ChiselExecutionOptions, dut: () => Module): ChiselExecutionResult = {
+    val circuit = elaborate(dut)
+
+    // this little hack let's us set the topName with the circuit name if it has not been set from args
+    chiselExecutionOptions.setTopNameIfUnset(circuit.name)
+
+    // use input because firrtl will be reading this
+    val firrtlString = Emitter.emit(circuit)
+    val firrtlFileName = chiselExecutionOptions.inputFileName
+    val firrtlFile = new File(firrtlFileName)
+
+    val w = new FileWriter(firrtlFile)
+    w.write(firrtlString)
+    w.close()
+
+    val firrtlExecutionResult = if(chiselExecutionOptions.runFirrtlCompiler) {
+      Some(firrtl.Driver.execute(chiselExecutionOptions))
+    }
+    else {
+      None
+    }
+    ChiselExecutionSucccess(Some(circuit), firrtlString, firrtlExecutionResult)
+  }
+
+  /**
+    * Run the chisel3 compiler and possibly the firrtl compiler with options specified via an array of Strings
+    * @param args   The options specified, command line style
+    * @param dut    The device under test
+    * @return       An execution result with useful stuff, or failure with message
+    */
+  def execute(args: Array[String], dut: () => Module): ChiselExecutionResult = {
+    val chiselExecutionOptions = new ChiselExecutionOptions()
+
+    val parser = new OptionParser[Unit]("chisel3"){}
+    chiselExecutionOptions.addOptions(parser)
+
+    parser.parse(args) match {
+      case true =>
+        execute(chiselExecutionOptions, dut)
+      case _ =>
+        ChiselExecutionFailure("could not parse results")
+
+    }
+  }
+
+  /**
+    * This is just here as command line way to see what the options are
+    * It will not successfully run
+    * TODO: Look into dynamic class loading as way to make this main useful
+    *
+    * @param args unused args
+    */
+  def main(args: Array[String]) {
+    execute(Array("--help"), null)
+  }
 }

--- a/src/test/scala/chiselTests/DriverSpec.scala
+++ b/src/test/scala/chiselTests/DriverSpec.scala
@@ -7,10 +7,10 @@ import chisel3._
 import org.scalatest.{Matchers, FreeSpec}
 
 class DummyModule extends Module {
-  val io = new Bundle {
-    val in = UInt(1).flip()
-    val out = UInt(1)
-  }
+  val io = IO(new Bundle {
+    val in = UInt(INPUT, 1)
+    val out = UInt(OUTPUT, 1)
+  })
   io.out := io.in
 }
 

--- a/src/test/scala/chiselTests/DriverSpec.scala
+++ b/src/test/scala/chiselTests/DriverSpec.scala
@@ -1,0 +1,33 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+
+import org.scalatest.{Matchers, FreeSpec}
+
+class DummyModule extends Module {
+  val io = new Bundle {
+    val in = UInt(1).flip()
+    val out = UInt(1)
+  }
+  io.out := io.in
+}
+
+class DriverSpec extends FreeSpec with Matchers {
+  "Driver's execute methods are used to run chisel and firrtl" - {
+    "options can be picked up from comand line with no args" in {
+      Driver.execute(Array.empty[String], () => new DummyModule)
+    }
+    "options can be picked up from comand line setting top name" in {
+      Driver.execute(Array("-tn", "dm", "-td", "local-build"), () => new DummyModule)
+    }
+    "execute returns a chisel execution result" in {
+      val args = Array("--compiler", "low")
+      val result = Driver.execute(Array.empty[String], () => new DummyModule)
+      result shouldBe a[ChiselExecutionSucccess]
+      val successResult = result.asInstanceOf[ChiselExecutionSucccess]
+      successResult.emitted should include ("circuit DummyModule")
+    }
+  }
+}

--- a/src/test/scala/chiselTests/Reg.scala
+++ b/src/test/scala/chiselTests/Reg.scala
@@ -2,6 +2,7 @@
 
 package chiselTests
 
+import firrtl.ir.Input
 import org.scalatest._
 import chisel3._
 import chisel3.core.DataMirror


### PR DESCRIPTION
Provide support for chisel options
Provide support for firrtl options when called as part of chisel compile
provide command line support the above options via scopt
provide and execution result class that can be used when chisel3 is part
of some externally controlled toolchain

IMPORTANT: Do not merge until after release, must be merge in tandem with execute harness PR in firrtl