### PR TITLE
Give <> and := legacy behavior in compatibility mode

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -17,6 +17,8 @@ import chisel3.internal.sourceinfo.{SourceInfo, DeprecatedSourceInfo, VecTransfo
 sealed abstract class Aggregate extends Data {
   private[core] def cloneTypeWidth(width: Width): this.type = cloneType
   private[core] def width: Width = flatten.map(_.width).reduce(_ + _)
+  private[core] def legacyConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit =
+    pushCommand(BulkConnect(sourceInfo, this.lref, that.lref))
 }
 
 object Vec {

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -5,7 +5,7 @@ package chisel3.core
 import scala.language.experimental.macros
 
 import chisel3.internal._
-import chisel3.internal.Builder.pushOp
+import chisel3.internal.Builder.{pushCommand, pushOp}
 import chisel3.internal.firrtl._
 import chisel3.internal.sourceinfo.{SourceInfo, DeprecatedSourceInfo, SourceInfoTransform, SourceInfoWhiteboxTransform,
   UIntTransform, MuxTransform}
@@ -40,6 +40,9 @@ abstract class Element(private[core] val width: Width) extends Data {
   private[chisel3] final def allElements: Seq[Element] = Seq(this)
   def widthKnown: Boolean = width.known
   def name: String = getRef.name
+
+  private[core] def legacyConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit =
+    pushCommand(Connect(sourceInfo, this.lref, that.ref))
 }
 
 /** A data type for values represented by a single bitvector. Provides basic

--- a/chiselFrontend/src/main/scala/chisel3/core/CompileOptions.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/CompileOptions.scala
@@ -20,6 +20,8 @@ trait CompileOptions {
   // Issue a deprecation warning if Data.{flip, asInput,asOutput} is used
   // instead of Flipped, Input, or Output.
   val deprecateOldDirectionMethods: Boolean
+  // Check that referenced Data have actually been declared.
+  val checkSynthesizable: Boolean
 }
 
 object CompileOptions {
@@ -38,6 +40,7 @@ object ExplicitCompileOptions {
     val dontTryConnectionsSwapped = false
     val dontAssumeDirectionality = false
     val deprecateOldDirectionMethods = false
+    val checkSynthesizable = false
   }
 
   // Collection of "strict" connection compile options, preferred for new code.
@@ -49,5 +52,6 @@ object ExplicitCompileOptions {
     val dontTryConnectionsSwapped = true
     val dontAssumeDirectionality = true
     val deprecateOldDirectionMethods = true
+    val checkSynthesizable = true
   }
 }

--- a/src/test/scala/chiselTests/CompileOptionsTest.scala
+++ b/src/test/scala/chiselTests/CompileOptionsTest.scala
@@ -23,6 +23,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
     val dontTryConnectionsSwapped = true
     val dontAssumeDirectionality = true
     val deprecateOldDirectionMethods = true
+    val checkSynthesizable = true
   }
 
   class SmallBundle extends Bundle {
@@ -267,6 +268,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
         val dontTryConnectionsSwapped = true
         val dontAssumeDirectionality = true
         val deprecateOldDirectionMethods = false
+        val checkSynthesizable = true
       }
 
     }


### PR DESCRIPTION
This makes <> and := do what they did two weeks ago (bidirectional connect with weak semantics for aggregates; unidirectional connect with weak semantics for elements), so that legacy code that imports Chisel._ will work seamlessly.

This means legacy code may emit incorrect FIRRTL, as was the case before; only new code that imports chisel3._ will be safe from this possibility.