### PR TITLE
Make asInput/asOutput/flip deprecation warnings dynamic

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/CompileOptions.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/CompileOptions.scala
@@ -17,6 +17,9 @@ trait CompileOptions {
   val dontTryConnectionsSwapped: Boolean
   // If connection directionality is not explicit, do not use heuristics to attempt to determine it.
   val dontAssumeDirectionality: Boolean
+  // Issue a deprecation warning if Data.{flip, asInput,asOutput} is used
+  // instead of Flipped, Input, or Output.
+  val deprecateOldDirectionMethods: Boolean
 }
 
 object CompileOptions {
@@ -34,6 +37,7 @@ object ExplicitCompileOptions {
     val requireIOWrap = false
     val dontTryConnectionsSwapped = false
     val dontAssumeDirectionality = false
+    val deprecateOldDirectionMethods = false
   }
 
   // Collection of "strict" connection compile options, preferred for new code.
@@ -44,5 +48,6 @@ object ExplicitCompileOptions {
     val requireIOWrap = true
     val dontTryConnectionsSwapped = true
     val dontAssumeDirectionality = true
+    val deprecateOldDirectionMethods = true
   }
 }

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -104,12 +104,21 @@ object Data {
   }
 
   implicit class AddDirectionToData[T<:Data](val target: T) extends AnyVal {
-    @deprecated("Input(Data) should be used over Data.asInput", "gchisel")
-    def asInput: T = Input(target)
-    @deprecated("Output(Data) should be used over Data.asOutput", "gchisel")
-    def asOutput: T = Output(target)
-    @deprecated("Flipped(Data) should be used over Data.flip", "gchisel")
-    def flip(): T = Flipped(target)
+    def asInput(implicit opts: CompileOptions): T = {
+      if (opts.deprecateOldDirectionMethods)
+        Builder.deprecated("Input(Data) should be used over Data.asInput")
+      Input(target)
+    }
+    def asOutput(implicit opts: CompileOptions): T = {
+      if (opts.deprecateOldDirectionMethods)
+        Builder.deprecated("Output(Data) should be used over Data.asOutput")
+      Output(target)
+    }
+    def flip()(implicit opts: CompileOptions): T = {
+      if (opts.deprecateOldDirectionMethods)
+        Builder.deprecated("Flipped(Data) should be used over Data.flip")
+      Flipped(target)
+    }
   }
 }
 

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -173,6 +173,8 @@ private[chisel3] object Builder {
 
   def errors: ErrorLog = dynamicContext.errors
   def error(m: => String): Unit = errors.error(m)
+  def warning(m: => String): Unit = errors.warning(m)
+  def deprecated(m: => String): Unit = errors.deprecated(m)
 
   def build[T <: Module](f: => T): Circuit = {
     dynamicContextVar.withValue(Some(new DynamicContext())) {

--- a/chiselFrontend/src/main/scala/chisel3/internal/Error.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Error.scala
@@ -25,6 +25,10 @@ private[chisel3] class ErrorLog {
   def warning(m: => String): Unit =
     errors += new Warning(m, getUserLineNumber)
 
+  /** Log a deprecation warning message */
+  def deprecated(m: => String): Unit =
+    errors += new DeprecationWarning(m, getUserLineNumber)
+
   /** Emit an informational message */
   def info(m: String): Unit =
     println(new Info("[%2.3f] %s".format(elapsedTime/1e3, m), None))  // scalastyle:ignore regex
@@ -84,6 +88,10 @@ private class Error(msg: => String, line: Option[StackTraceElement]) extends Log
 
 private class Warning(msg: => String, line: Option[StackTraceElement]) extends LogEntry(msg, line) {
   def format: String = tag("warn", Console.YELLOW)
+}
+
+private class DeprecationWarning(msg: => String, line: Option[StackTraceElement]) extends LogEntry(msg, line) {
+  def format: String = tag("warn", Console.CYAN)
 }
 
 private class Info(msg: => String, line: Option[StackTraceElement]) extends LogEntry(msg, line) {

--- a/src/test/scala/chiselTests/CompileOptionsTest.scala
+++ b/src/test/scala/chiselTests/CompileOptionsTest.scala
@@ -22,6 +22,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
     val requireIOWrap = false
     val dontTryConnectionsSwapped = true
     val dontAssumeDirectionality = true
+    val deprecateOldDirectionMethods = true
   }
 
   class SmallBundle extends Bundle {
@@ -265,6 +266,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
         val requireIOWrap = false
         val dontTryConnectionsSwapped = true
         val dontAssumeDirectionality = true
+        val deprecateOldDirectionMethods = false
       }
 
     }


### PR DESCRIPTION
Code that imports Chisel._ shouldn't see them.

Not sure if requireIOWrap is the right condition... or if cyan is a
good choice of color for deprecation warnings.