### PR TITLE
Change verilogToCpp to use O0

### DIFF
--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -119,13 +119,13 @@ trait BackendCompilationUtilities {
         "-Wno-WIDTH",
         "-Wno-STMTDLY",
         "--trace",
-        "-O2",
+        "-O0",
         "--top-module", topModule,
         "+define+TOP_TYPE=V" + dutFile,
         s"+define+PRINTF_COND=!$topModule.reset",
         s"+define+STOP_COND=!$topModule.reset",
         "-CFLAGS",
-        s"""-Wno-undefined-bool-conversion -O2 -DTOP_TYPE=V$dutFile -include V$dutFile.h""",
+        s"""-Wno-undefined-bool-conversion -O0 -DTOP_TYPE=V$dutFile -include V$dutFile.h""",
         "-Mdir", dir.toString,
         "--exe", cppHarness.toString)
     System.out.println(s"${command.mkString(" ")}") // scalastyle:ignore regex


### PR DESCRIPTION
This causes Verilator tests to compile faster and use less memory

I'm PRing this because Firrtl Travis checks out chisel3 and then runs sbt test. Firrtl Travis builds are failing due to g++ using too much memory. Using O0 is fixing the problem

Generally, projects that want O2 are going to be invoking Verilator themselves, so I think it's reasonable that the built-in Verilator invocation uses O0.