### PR TITLE
fix SeqMem's read port creation

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
@@ -147,7 +147,11 @@ sealed class SeqMem[T <: Data](t: T, n: Int) extends MemBase[T](t, n) {
   def read(addr: UInt, enable: Bool): T = {
     implicit val sourceInfo = UnlocatableSourceInfo
     val a = Wire(UInt())
-    when (enable) { a := addr }
-    read(a)
+    var port: Option[T] = None
+    when (enable) {
+      a := addr
+      port = Some(read(a))
+    }
+    port.get
   }
 }


### PR DESCRIPTION
Unfortunately, 41674d5e130f64d7489fdb8583b8f4ad88b64aeb broke read enable inference for SeqMems in `RemoveCHIRRTL` of firrtl, and also broke `inferReadWrite` because port creation generates additional wires to truncate index bits. This will help firrtl correctly infer read enables for SeqMems.