### PR TITLE
Preserve legacy cloneType behavior in compatibility mode

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -294,7 +294,7 @@ sealed abstract class Bits(width: Width, override val litArg: Option[LitArg])
     pushOp(DefPrim(sourceInfo, UInt(w), ConcatOp, this.ref, that.ref))
   }
 
-  override def do_fromBits(that: Bits)(implicit sourceInfo: SourceInfo): this.type = {
+  override def do_fromBits(that: Bits)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): this.type = {
     val res = Wire(this, null).asInstanceOf[this.type]
     res := that
     res

--- a/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
@@ -9,6 +9,7 @@ import chisel3.internal.sourceinfo.{SourceInfo, UnlocatableSourceInfo}
 
 object Reg {
   private[core] def makeType[T <: Data](compileOptions: CompileOptions, t: T = null, next: T = null, init: T = null): T = {
+    implicit val myCompileOptions = compileOptions
     if (t ne null) {
       if (compileOptions.declaredTypeMustBeUnbound) {
         Binding.checkUnbound(t, s"t ($t) must be unbound Type. Try using cloneType?")

--- a/chiselFrontend/src/main/scala/chisel3/core/SeqUtils.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/SeqUtils.scala
@@ -4,7 +4,7 @@ package chisel3.core
 
 import scala.language.experimental.macros
 
-import chisel3.internal.sourceinfo.{SourceInfo, SourceInfoTransform}
+import chisel3.internal.sourceinfo._
 
 private[chisel3] object SeqUtils {
   /** Concatenates the data elements of the input sequence, in sequence order, together.
@@ -51,9 +51,9 @@ private[chisel3] object SeqUtils {
     *
     * @note assumes exactly one true predicate, results undefined otherwise
     */
-  def oneHotMux[T <: Data](in: Iterable[(Bool, T)]): T = macro SourceInfoTransform.inArg
+  def oneHotMux[T <: Data](in: Iterable[(Bool, T)]): T = macro CompileOptionsTransform.inArg
 
-  def do_oneHotMux[T <: Data](in: Iterable[(Bool, T)])(implicit sourceInfo: SourceInfo): T = {
+  def do_oneHotMux[T <: Data](in: Iterable[(Bool, T)])(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     if (in.tail.isEmpty) {
       in.head._2
     } else {

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -24,13 +24,14 @@ trait SourceInfoTransformMacro {
   import c.universe._
   def thisObj = c.prefix.tree
   def implicitSourceInfo = q"implicitly[_root_.chisel3.internal.sourceinfo.SourceInfo]"
+  def implicitCompileOptions = q"implicitly[_root_.chisel3.core.CompileOptions]"
 }
 
 class WireTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
   def apply[T: c.WeakTypeTag](t: c.Tree): c.Tree = {
     val tpe = weakTypeOf[T]
-    q"$thisObj.do_apply($t, null.asInstanceOf[$tpe])($implicitSourceInfo)"
+    q"$thisObj.do_apply($t, null.asInstanceOf[$tpe])($implicitSourceInfo, $implicitCompileOptions)"
   }
 }
 
@@ -75,16 +76,16 @@ class MuxTransform(val c: Context) extends SourceInfoTransformMacro {
 class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
   def apply_elts(elts: c.Tree): c.Tree = {
-    q"$thisObj.do_apply($elts)($implicitSourceInfo)"
+    q"$thisObj.do_apply($elts)($implicitSourceInfo, $implicitCompileOptions)"
   }
   def apply_elt0(elt0: c.Tree, elts: c.Tree*): c.Tree = {
-    q"$thisObj.do_apply($elt0, ..$elts)($implicitSourceInfo)"
+    q"$thisObj.do_apply($elt0, ..$elts)($implicitSourceInfo, $implicitCompileOptions)"
   }
   def tabulate(n: c.Tree)(gen: c.Tree): c.Tree = {
-    q"$thisObj.do_tabulate($n)($gen)($implicitSourceInfo)"
+    q"$thisObj.do_tabulate($n)($gen)($implicitSourceInfo, $implicitCompileOptions)"
   }
   def fill(n: c.Tree)(gen: c.Tree): c.Tree = {
-    q"$thisObj.do_fill($n)($gen)($implicitSourceInfo)"
+    q"$thisObj.do_fill($n)($gen)($implicitSourceInfo, $implicitCompileOptions)"
   }
   def contains(x: c.Tree)(ev: c.Tree): c.Tree = {
     q"$thisObj.do_contains($x)($implicitSourceInfo, $ev)"
@@ -137,6 +138,22 @@ class SourceInfoTransform(val c: Context) extends AutoSourceTransform {
 
   def xyArg(x: c.Tree, y: c.Tree): c.Tree = {
     q"$thisObj.$doFuncTerm($x, $y)($implicitSourceInfo)"
+  }
+}
+
+class CompileOptionsTransform(val c: Context) extends AutoSourceTransform {
+  import c.universe._
+
+  def thatArg(that: c.Tree): c.Tree = {
+    q"$thisObj.$doFuncTerm($that)($implicitSourceInfo, $implicitCompileOptions)"
+  }
+
+  def inArg(in: c.Tree): c.Tree = {
+    q"$thisObj.$doFuncTerm($in)($implicitSourceInfo, $implicitCompileOptions)"
+  }
+
+  def pArg(p: c.Tree): c.Tree = {
+    q"$thisObj.$doFuncTerm($p)($implicitSourceInfo, $implicitCompileOptions)"
   }
 }
 


### PR DESCRIPTION
f1507aa7cec86ca8f5de13ddc96fd046370dfe1d is a compatibility-mode regression, since previously cloneType did not preserve flippedness.  Disable this new behavior whenever legacy connection behavior is in effect (i.e., !checkSynthesizable).

This fix is made more complicated by several holes CompileOptions propagation.  defaultCompileOptions frequently foils the compatibility layer by providing strict defaults rather than inheriting the user's CompileOptions.  In this case, it manifests when the Vec internals invoke the wrong cloneType behavior.

This patch removes all reliance on defaultCompileOptions within chisel3.core.  Ideally, we'd statically prevent it from being used in the internals, and only supply it to people who import chisel3.  Not sure how feasible that is.