### PR TITLE
Add initialization functionality to Counters.

### DIFF
--- a/src/main/scala/chisel3/util/Counter.scala
+++ b/src/main/scala/chisel3/util/Counter.scala
@@ -10,9 +10,10 @@ import chisel3._
   * @param n number of counts before the counter resets (or one more than the
   * maximum output value of the counter), need not be a power of two
   */
-class Counter(val n: Int) {
+class Counter(val n: Int, val init: Int = 0) {
   require(n >= 0)
-  val value = if (n > 1) Reg(init=0.U(log2Up(n).W)) else 0.U
+  require(init < n || (n == 0 && init == 0))
+  val value = if (n > 1) Reg(init=init.U(log2Up(n).W)) else 0.U
 
   /** Increment the counter, returning whether the counter currently is at the
     * maximum and will wrap. The incremented value is registered and will be
@@ -30,6 +31,12 @@ class Counter(val n: Int) {
       true.B
     }
   }
+
+  /** Reset the counter to the init value.
+   */
+  def restart(): Unit = {
+    if (n > 1) value := init.U
+  }
 }
 
 object Counter
@@ -37,6 +44,10 @@ object Counter
   /** Instantiate a [[Counter! counter]] with the specified number of counts.
     */
   def apply(n: Int): Counter = new Counter(n)
+
+  /** Instantiate a [[Counter! counter]] with the specified number of counts and an init value.
+   */
+  def apply(n: Int, init: Int) = new Counter(n, init)
 
   /** Instantiate a [[Counter! counter]] with the specified number of counts and a gate.
    *
@@ -57,6 +68,20 @@ object Counter
     val c = new Counter(n)
     var wrap: Bool = null
     when (cond) { wrap = c.inc() }
+    (c.value, cond && wrap)
+  }
+
+  /** Instantiate a [[Counter! counter]] with the specified number of counts, a gate, and a restart.
+   */
+  def apply(cond: Bool, n: Int, restart: Bool): (UInt, Bool) = apply(cond, n, restart, 0)
+
+  /** Instantiate a [[Counter! counter]] with the specified number of counts, a gate, a restart, and an init.
+   */
+  def apply(cond: Bool, n: Int, restart: Bool, init: Int): (UInt, Bool) = {
+    val c = new Counter(n, init)
+    var wrap: Bool = null
+    when (cond) { wrap = c.inc() }
+    when (restart && cond) { c.restart() }
     (c.value, cond && wrap)
   }
 }

--- a/src/test/scala/chiselTests/Counter.scala
+++ b/src/test/scala/chiselTests/Counter.scala
@@ -9,6 +9,8 @@ import chisel3._
 import chisel3.testers.BasicTester
 import chisel3.util._
 
+import scala.math.{min, max}
+
 class CountTester(max: Int) extends BasicTester {
   val cnt = Counter(max)
   when(true.B) { cnt.inc() }
@@ -38,6 +40,21 @@ class WrapTester(max: Int) extends BasicTester {
   }
 }
 
+class InitTester(max: Int, init: Int) extends BasicTester {
+  val cntFromInit = Counter(max, init)
+  cntFromInit.inc()
+  
+  val cntFromZero = Counter(max)
+  val wrap = cntFromZero.inc()
+
+  val restart = if (init > 0) cntFromZero.value === (init - 1).U else false.B
+  when (restart) { cntFromInit.restart() }
+
+  assert(! (cntFromZero.value >  init.U) || (cntFromInit.value === cntFromZero.value) )
+
+  when (wrap) { stop() }
+}
+
 class CounterSpec extends ChiselPropSpec {
   property("Counter should count up") {
     forAll(smallPosInts) { (max: Int) => assertTesterPasses{ new CountTester(max) } }
@@ -49,5 +66,11 @@ class CounterSpec extends ChiselPropSpec {
 
   property("Counter should wrap") {
     forAll(smallPosInts) { (max: Int) => assertTesterPasses{ new WrapTester(max) } }
+  }
+
+  property("Counter should init and restart") {
+    forAll(smallPosInts, smallPosInts) { (x: Int, y: Int) => if (x > y) assertTesterPasses{
+      new InitTester(x, y) 
+    } }
   }
 }


### PR DESCRIPTION
Sometimes I want to be able to start counters at some non-zero value.

Currently, we have one of our own counters living in [dsptools](ucb-bar/dsptools). I'm totally open to it staying there, but it seems to me like the out-of-the-box counter could have more features. Looking at the counters in [rocket](https://github.com/ucb-bar/rocket-chip/blob/master/src/main/scala/util/Counters.scala), it looks like at least the `TwoWayCounter` could make sense in chisel instead. 

It looks like @zhemao was responsible for the rocket counters, and @aswaterman and @ducky64 responsible for the chisel counter. What do you guys think?