### PR TITLE
[stevo]: allow bitwidth inference on output of shift register

### DIFF
--- a/src/main/scala/chisel3/util/Reg.scala
+++ b/src/main/scala/chisel3/util/Reg.scala
@@ -58,7 +58,8 @@ object ShiftRegister
     if (n == 1) {
       RegEnable(in, en)
     } else if (n != 0) {
-      RegNext(apply(in, n-1, en))
+      val next = apply(in, n-1, en)
+      Reg[T](next.cloneType, next, null.asInstanceOf[T])
     } else {
       in
     }


### PR DESCRIPTION
Chisel couldn't find bitwidth when I tried to use

Reverse(ShiftRegister(value, 2))

because Reverse calls getWidth. This fixes that issue.  See #354 for the old fix attempt, where I changed RegNext instead of ShiftRegister