### PR TITLE
[stevo]: shift register enable signal now enables ALL registers in th…

### DIFF
--- a/src/main/scala/chisel3/util/Reg.scala
+++ b/src/main/scala/chisel3/util/Reg.scala
@@ -55,9 +55,7 @@ object ShiftRegister
     */
   def apply[T <: Data](in: T, n: Int, en: Bool = Bool(true)): T = {
     // The order of tests reflects the expected use cases.
-    if (n == 1) {
-      RegEnable(in, en)
-    } else if (n != 0) {
+    if (n != 0) {
       RegEnable(apply(in, n-1, en), en)
     } else {
       in

--- a/src/main/scala/chisel3/util/Reg.scala
+++ b/src/main/scala/chisel3/util/Reg.scala
@@ -58,7 +58,7 @@ object ShiftRegister
     if (n == 1) {
       RegEnable(in, en)
     } else if (n != 0) {
-      RegNext(apply(in, n-1, en))
+      RegEnable(apply(in, n-1, en), en)
     } else {
       in
     }


### PR DESCRIPTION
…e chain.

Previously, the enable signal only worked on the first register. Later ones still shifted every cycle. Now they are all controlled by en.

This also fixes the problem in PR #355, so I'll close that one in favor of this one.
