### PR TITLE
Eliminate some doc warnings

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Binding.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Binding.scala
@@ -140,10 +140,9 @@ object Binding {
       }
     }
 
-    /** Diagnose a binding error caused by a missing IO() wrapper.
-      * @param element the element triggering the binding error.
-      * @return true if the element is a member of the module's io but ioDefined is false.
-      */
+    // Diagnose a binding error caused by a missing IO() wrapper.
+    // element is the element triggering the binding error.
+    // Returns true if the element is a member of the module's io but ioDefined is false.
     def isMissingIOWrapper(element: Element): Boolean = {
       element._parent match {
         case None => false

--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -95,7 +95,7 @@ trait BackendCompilationUtilities {
   /** Generates a Verilator invocation to convert Verilog sources to C++
     * simulation sources.
     *
-    * The Verilator prefix will be V$dutFile, and running this will generate
+    * The Verilator prefix will be V\$dutFile, and running this will generate
     * C++ sources and headers as well as a makefile to compile them.
     *
     * @param dutFile name of the DUT .v without the .v extension

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -230,7 +230,7 @@ extends Module(override_reset=override_reset) {
   * @param enq input (enqueue) interface to the queue, also determines width of queue elements
   * @param entries depth (number of elements) of the queue
   *
-  * @returns output (dequeue) interface from the queue
+  * @return output (dequeue) interface from the queue
   *
   * @example {{{
   * consumer.io.in <> Queue(producer.io.out, 16)


### PR DESCRIPTION
So when you do `sbt publish-local` or `sbt doc` you can have three less warnings.

The one that I couldn't fix is in Data.getWidth in Data.scala, where it has `@throws java.util.NoSuchElementException` that scaladoc can't generate the link for (since NoSuchElementException isn't in Chisel). One possible workaround is to disable all link warnings, but a proper clean fix would probably need to be in the scaladoc generator itself.