### PR TITLE
ScalaCheck may shrink to fail DecoderSpec.

### DIFF
--- a/src/test/scala/chiselTests/Decoder.scala
+++ b/src/test/scala/chiselTests/Decoder.scala
@@ -33,6 +33,9 @@ class DecoderTester(pairs: List[(String, String)]) extends BasicTester {
 }
 
 class DecoderSpec extends ChiselPropSpec {
+  // Inhibit shrinking for this test, otherwise, we may end up generating an empty List of pairs which is guaranteed to fail.
+  import org.scalacheck.Shrink
+  implicit val noShrink: Shrink[Int] = Shrink.shrinkAny
 
   // Use a single Int to make both a specific instruction and a BitPat that will match it
   val bitpatPair = for(seed <- Arbitrary.arbitrary[Int]) yield {


### PR DESCRIPTION
We either need to set constraints on the nPairs generator so it doesn't generate an empty list, or ignore empty lists when running tests. This was triggered by a recent Jenkins failure:

    [info] - BitPat wildcards should be usable in decoding *** FAILED ***
    [info]   IllegalArgumentException was thrown during property evaluation.
    [info]     Message: requirement failed
    [info]     Occurred when passed generated values (
    [info]       arg0 = List() // 3 shrinks
    [info]     )