### PR TITLE
Default to no dequeue in Queue factory methods

### DIFF
--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -248,6 +248,7 @@ object Queue
     q.io.enq.valid := enq.valid // not using <> so that override is allowed
     q.io.enq.bits := enq.bits
     enq.ready := q.io.enq.ready
+    q.io.deq.ready := false.B  // Default to no dequeue
     TransitName(q.io.deq, q)
   }
 
@@ -266,6 +267,7 @@ object Queue
     irr.bits := deq.bits
     irr.valid := deq.valid
     deq.ready := irr.ready
+    irr.ready := false.B
     irr
   }
 }


### PR DESCRIPTION
In my opinion, Queue factory methods should default the Queue output to no dequeuing

Most of the time Queue.apply is used the result is instantly bulk connected to something else, this has no effect on those uses (except I guess an extra line of Firrtl that goes away).

However, other use cases where some Decoupled input is being buffered and then used, it seems natural that it should default to "no dequeue" the output of the Queue.

eg.
```scala
val myQ = Queue(io.input)
myQ.nodeq() // equivalent to myQ.ready := false.B  <- This line seems super unnecessary
when (cond) {
  val bits = myQ.deq()
  // Do something with bits
}

