### PR TITLE
Private vals

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -199,8 +199,13 @@ extends HasId {
           }
         case _ => // Do nothing
       }
+    /** Scala generates names like chisel3$util$Queue$$ram for private vals
+      * This extracts the part after $$ for names like this and leaves names
+      * without $$ unchanged
+      */
+    def cleanName(name: String): String = name.split("""\$\$""").lastOption.getOrElse(name)
     for (m <- getPublicFields(classOf[Module])) {
-      nameRecursively(m.getName, m.invoke(this))
+      nameRecursively(cleanName(m.getName), m.invoke(this))
     }
 
     // For Module instances we haven't named, suggest the name of the Module

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -175,16 +175,16 @@ extends Module(override_reset=override_reset) {
 
   val io = IO(new QueueIO(gen, entries))
 
-  val ram = Mem(entries, gen)
-  val enq_ptr = Counter(entries)
-  val deq_ptr = Counter(entries)
-  val maybe_full = Reg(init=false.B)
+  private val ram = Mem(entries, gen)
+  private val enq_ptr = Counter(entries)
+  private val deq_ptr = Counter(entries)
+  private val maybe_full = Reg(init=false.B)
 
-  val ptr_match = enq_ptr.value === deq_ptr.value
-  val empty = ptr_match && !maybe_full
-  val full = ptr_match && maybe_full
-  val do_enq = Wire(init=io.enq.fire())
-  val do_deq = Wire(init=io.deq.fire())
+  private val ptr_match = enq_ptr.value === deq_ptr.value
+  private val empty = ptr_match && !maybe_full
+  private val full = ptr_match && maybe_full
+  private val do_enq = Wire(init=io.enq.fire())
+  private val do_deq = Wire(init=io.deq.fire())
 
   when (do_enq) {
     ram(enq_ptr.value) := io.enq.bits
@@ -214,7 +214,7 @@ extends Module(override_reset=override_reset) {
     when (io.deq.ready) { io.enq.ready := true.B }
   }
 
-  val ptr_diff = enq_ptr.value - deq_ptr.value
+  private val ptr_diff = enq_ptr.value - deq_ptr.value
   if (isPow2(entries)) {
     io.count := Cat(maybe_full && ptr_match, ptr_diff)
   } else {


### PR DESCRIPTION
After looking at the public API for Queue (see all of the public vals https://chisel.eecs.berkeley.edu/api/index.html#chisel3.util.Queue), I wanted to clean it up a little bit.

So it turns out that Chisel already names private vals, Scala just gives them really crazy names (like chisel3$util$Queue$$ram) so I wrote a function to clean these names up. I have not been able to figure out a way to detect if something is a private val via java reflection so this cleanup is my hacky alternative. Suggestions welcome.

I also changed all of the public fields in util that I could find that have no business being public (since accessing them externally would result in invalid Firrtl)