### PR TITLE
Can The Spam: disable reflective call warnings on tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -126,6 +126,7 @@ lazy val chisel = (project in file(".")).
   dependsOn(coreMacros % "compile-internal;test-internal").
   dependsOn(chiselFrontend % "compile-internal;test-internal").
   settings(
+    scalacOptions in Test ++= Seq("-language:reflectiveCalls"),
     aggregate in doc := false,
     // Include macro classes, resources, and sources main JAR.
     mappings in (Compile, packageBin) <++= mappings in (coreMacros, Compile, packageBin),


### PR DESCRIPTION
Workaround for #401.

It might also be a good idea to address this as the recommended way in template projects and documentation: users should have feature warnings, but should disable reflective call warnings in Chisel RTL.