### PR TITLE
Make stop() immediately end simulation for Verilator tests

### DIFF
--- a/src/main/resources/top.cpp
+++ b/src/main/resources/top.cpp
@@ -5,6 +5,13 @@
 # include <verilated_vcd_c.h>	// Trace file format header
 #endif
 
+// Override Verilator definition so first $finish ends simulation
+// Note: VL_USER_FINISH needs to be defined when compiling Verilator code
+void vl_finish(const char* filename, int linenum, const char* hier) {
+  Verilated::flushCall();
+  exit(0);
+}
+
 using namespace std;
 
 //VGCDTester *top;

--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -128,7 +128,7 @@ trait BackendCompilationUtilities {
         s"+define+PRINTF_COND=!$topModule.reset",
         s"+define+STOP_COND=!$topModule.reset",
         "-CFLAGS",
-        s"""-Wno-undefined-bool-conversion -O1 -DTOP_TYPE=V$dutFile -include V$dutFile.h""",
+        s"""-Wno-undefined-bool-conversion -O1 -DTOP_TYPE=V$dutFile -DVL_USER_FINISH -include V$dutFile.h""",
         "-Mdir", dir.toString,
         "--exe", cppHarness.toString)
     System.out.println(s"${command.mkString(" ")}") // scalastyle:ignore regex

--- a/src/test/scala/chiselTests/Harness.scala
+++ b/src/test/scala/chiselTests/Harness.scala
@@ -43,6 +43,11 @@ int main(int argc, char **argv, char **env) {
     delete top;
     exit(0);
 }
+
+void vl_finish(const char* filename, int linenum, const char* hier) {
+  Verilated::flushCall();
+  exit(0);
+}
 """, ".cpp") _
 
   /** Compiles a C++ emulator from Verilog and returns the path to the

--- a/src/test/scala/chiselTests/Stop.scala
+++ b/src/test/scala/chiselTests/Stop.scala
@@ -10,8 +10,21 @@ class StopTester() extends BasicTester {
   stop()
 }
 
+class StopImmediatelyTester extends BasicTester {
+  val cycle = Reg(init = 0.asUInt(4.W))
+  cycle := cycle + 1.U
+  when (cycle === 4.U) {
+    stop()
+  }
+  assert(cycle =/= 5.U, "Simulation did not exit upon executing stop()")
+}
+
 class StopSpec extends ChiselFlatSpec {
   "stop()" should "stop and succeed the testbench" in {
     assertTesterPasses { new StopTester }
+  }
+
+  it should "end the simulation immediately" in {
+    assertTesterPasses { new StopImmediatelyTester }
   }
 }


### PR DESCRIPTION
As seen in https://github.com/ucb-bar/chisel3/pull/422, you currently need to double stop() to actually stop in Verilator, this fixes that for our tests.