### PR TITLE
Make EnqIO (output of queue) IrrevocableIO, reflecting queue guarantees

### DIFF
--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -103,7 +103,7 @@ object Decoupled
   * Additionally, once 'valid' is raised it will never be lowered until after
   * 'ready' has also been raised.
   */
-class IrrevocableIO[+T <: Data](gen: T) extends ReadyValidIO[T](gen)
+class IrrevocableIO[+T <: Data](gen: T) extends DecoupledIO[T](gen)
 {
   override def cloneType: this.type = new IrrevocableIO(gen).asInstanceOf[this.type]
 }
@@ -129,7 +129,7 @@ object Irrevocable
 }
 
 object EnqIO {
-  def apply[T<:Data](gen: T): DecoupledIO[T] = Decoupled(gen)
+  def apply[T<:Data](gen: T): IrrevocableIO[T] = Irrevocable(gen)
 }
 object DeqIO {
   def apply[T<:Data](gen: T): DecoupledIO[T] = Flipped(Decoupled(gen))


### PR DESCRIPTION
Two changes:

`IrrevocableIO` is now a subtype of `DecoupledIO`, which was already assumed and implied by the documentation of the up/downconversions between them.

`EnqIO` (the object used to create the output of  `Queue`) now returns an instance of type `IrrevocableIO`, which reflects a guarantee provided by queues. This seems more-or-less to be central to the "queue-ness" of a module.

Understandably, this creates a new burden that must be maintained in future implementations to avoid breaking the API. This enables users of `AdvTester` to use queues properly on the outputs of their designs.

