### PR TITLE
Move blackbox verilog implementations within reach of verilator

### DIFF
--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -114,10 +114,23 @@ trait BackendCompilationUtilities {
       vSources: Seq[File],
       cppHarness: File
                   ): ProcessBuilder = {
-    val command = Seq("verilator",
-      "--cc", s"$dutFile.v") ++
+    val blackBoxVerilogList = {
+      val list_file = new File(dir, firrtl.transforms.BlackBoxSourceHelper.FileListName)
+      if(list_file.exists()) {
+        Seq("-f", list_file.getAbsolutePath)
+      }
+      else {
+        Seq.empty[String]
+      }
+    }
+    val command = Seq(
+        "verilator",
+        "--cc", s"$dutFile.v"
+      ) ++
+      blackBoxVerilogList ++
       vSources.map(file => Seq("-v", file.toString)).flatten ++
-      Seq("--assert",
+      Seq(
+        "--assert",
         "-Wno-fatal",
         "-Wno-WIDTH",
         "-Wno-STMTDLY",

--- a/src/main/scala/chisel3/util/BlackBoxUtils.scala
+++ b/src/main/scala/chisel3/util/BlackBoxUtils.scala
@@ -1,0 +1,24 @@
+// See LICENSE for license details.
+
+package chisel3.util
+
+import chisel3._
+import chisel3.core.ChiselAnnotation
+import firrtl.transforms.{BlackBoxInline, BlackBoxResource, BlackBoxSourceHelper}
+
+trait HasBlackBoxResource extends BlackBox {
+  self: Module =>
+
+  def setResource(blackBoxResource: String): Unit = {
+    annotate(ChiselAnnotation(self, classOf[BlackBoxSourceHelper], BlackBoxResource(blackBoxResource).serialize))
+  }
+}
+
+trait HasBlackBoxInline extends BlackBox {
+  self: Module =>
+
+  def setInline(blackBoxName: String, blackBoxInline: String): Unit = {
+    annotate(ChiselAnnotation(
+      self, classOf[BlackBoxSourceHelper], BlackBoxInline(blackBoxName, blackBoxInline).serialize))
+  }
+}

--- a/src/test/resources/BlackBoxTest.v
+++ b/src/test/resources/BlackBoxTest.v
@@ -12,6 +12,14 @@ module BlackBoxPassthrough(
   assign out = in;
 endmodule
 
+module BlackBoxMinus(
+    input  [15:0] in1,
+    input  [15:0] in2,
+    output [15:0] out
+);
+  assign out = in1 + in2;
+endmodule
+
 module BlackBoxRegister(
     input  [0:0] clock,
     input  [0:0] in,

--- a/src/test/scala/chiselTests/BlackBoxImpl.scala
+++ b/src/test/scala/chiselTests/BlackBoxImpl.scala
@@ -1,0 +1,92 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import java.io.File
+
+import chisel3._
+import chisel3.util.{HasBlackBoxInline, HasBlackBoxResource}
+import firrtl.FirrtlExecutionSuccess
+import org.scalacheck.Test.Failed
+import org.scalatest.{FreeSpec, Matchers, Succeeded}
+
+//scalastyle:off magic.number
+
+class BlackBoxAdd(n : Int) extends HasBlackBoxInline {
+  val io = IO(new Bundle {
+    val in = Input(UInt(16.W))
+    val out = Output(UInt(16.W))
+  })
+
+  //scalastyle:off regex
+  setInline("BlackBoxAdd.v",
+    s"""
+      |module BlackBoxAdd(
+      |    input  [15:0] in,
+      |    output [15:0] out
+      |);
+      |  assign out = in + $n;
+      |endmodule
+    """.stripMargin)
+}
+
+class UsesBlackBoxAddViaInline extends Module {
+  val io = IO(new Bundle {
+    val in = Input(UInt(16.W))
+    val out = Output(UInt(16.W))
+  })
+
+  val blackBoxAdd = Module(new BlackBoxAdd(5))
+  blackBoxAdd.io.in := io.in
+  io.out := blackBoxAdd.io.out
+}
+
+class BlackBoxMinus extends HasBlackBoxResource {
+  val io = IO(new Bundle {
+    val in1 = Input(UInt(16.W))
+    val in2 = Input(UInt(16.W))
+    val out = Output(UInt(16.W))
+  })
+  setResource("/BlackBoxTest.v")
+}
+
+class UsesBlackBoxMinusViaResource extends Module {
+  val io = IO(new Bundle {
+    val in1 = Input(UInt(16.W))
+    val in2 = Input(UInt(16.W))
+    val out = Output(UInt(16.W))
+  })
+
+  val mod0 = Module(new BlackBoxMinus)
+
+  mod0.io.in1 := io.in1
+  mod0.io.in2 := io.in2
+  io.out := mod0.io.out
+}
+
+class BlackBoxImplSpec extends FreeSpec with Matchers {
+  "BlackBox can have verilator source implementation" - {
+    "Implementations can be contained in-line" in {
+      Driver.execute(Array("-X", "verilog"), () => new UsesBlackBoxAddViaInline) match {
+        case ChiselExecutionSucccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
+          val verilogOutput = new File("./BlackBoxAdd.v")
+          verilogOutput.exists() should be (true)
+          verilogOutput.delete()
+          Succeeded
+        case _ =>
+          Failed
+      }
+    }
+    "Implementations can be contained in resource files" in {
+      Driver.execute(Array("-X", "low"), () => new UsesBlackBoxMinusViaResource) match {
+        case ChiselExecutionSucccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
+          val verilogOutput = new File("./BlackBoxTest.v")
+          verilogOutput.exists() should be (true)
+          verilogOutput.delete()
+          Succeeded
+        case _ =>
+          Failed
+      }
+    }
+  }
+}


### PR DESCRIPTION
FOR REVIEW:  depends on [Firrtl PR#418](https://github.com/ucb-bar/firrtl/pull/418)
Blackbox implementers can annotate the modules with information on where to get the source verilog.
This API is very lightweight, real work is done in firrtl in companion PR
Added some verilog to BlackBoxTest.v resource for testing