### PR TITLE
Deprecate old Reg with nulls constructor

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -529,6 +529,7 @@ sealed class UInt private[core] (width: Width, lit: Option[ULit] = None)
         throwException(s"cannot call $this.asFixedPoint(binaryPoint=$binaryPoint), you must specify a known binaryPoint")
     }
   }
+
   private[core] override def connectFromBits(that: Bits)(implicit sourceInfo: SourceInfo,
       compileOptions: CompileOptions): Unit = {
     this := that.asUInt
@@ -672,6 +673,7 @@ sealed class SInt private[core] (width: Width, lit: Option[SLit] = None)
         throwException(s"cannot call $this.asFixedPoint(binaryPoint=$binaryPoint), you must specify a known binaryPoint")
     }
   }
+
   private[core] override def connectFromBits(that: Bits)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions) {
     this := that.asSInt
   }
@@ -897,6 +899,7 @@ sealed class FixedPoint private (width: Width, val binaryPoint: BinaryPoint, lit
 
   override def do_asUInt(implicit sourceInfo: SourceInfo): UInt = pushOp(DefPrim(sourceInfo, UInt(this.width), AsUIntOp, ref))
   override def do_asSInt(implicit sourceInfo: SourceInfo): SInt = pushOp(DefPrim(sourceInfo, SInt(this.width), AsSIntOp, ref))
+
   override def do_asFixedPoint(binaryPoint: BinaryPoint)(implicit sourceInfo: SourceInfo): FixedPoint = {
     binaryPoint match {
       case KnownBinaryPoint(value) =>

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -337,7 +337,7 @@ object Wire {
   // No source info since Scala macros don't yet support named / default arguments.
   def apply[T <: Data](dummy: Int = 0, init: T)(implicit compileOptions: CompileOptions): T = {
     val model = (init.litArg match {
-      // For e.g. Wire(init=UInt(0, k)), fix the Reg's width to k
+      // For e.g. Wire(init=0.U(k.W)), fix the Reg's width to k
       case Some(lit) if lit.forcedWidth => init.chiselCloneType
       case _ => init match {
         case init: Bits => init.cloneTypeWidth(Width())

--- a/chiselFrontend/src/main/scala/chisel3/core/MonoConnect.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/MonoConnect.scala
@@ -5,7 +5,7 @@ package chisel3.core
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl.Connect
 import scala.language.experimental.macros
-import chisel3.internal.sourceinfo.{DeprecatedSourceInfo, SourceInfo, SourceInfoTransform, UnlocatableSourceInfo, WireTransform}
+import chisel3.internal.sourceinfo.SourceInfo
 
 /**
 * MonoConnect.connect executes a mono-directional connection element-wise.

--- a/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Reg.scala
@@ -2,88 +2,97 @@
 
 package chisel3.core
 
+import scala.language.experimental.macros
+
 import chisel3.internal._
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl._
-import chisel3.internal.sourceinfo.{SourceInfo, UnlocatableSourceInfo}
+import chisel3.internal.sourceinfo.{SourceInfo}
 
 object Reg {
-  private[core] def makeType[T <: Data](compileOptions: CompileOptions, t: T = null, next: T = null, init: T = null): T = {
-    implicit val myCompileOptions = compileOptions
-    if (t ne null) {
-      if (compileOptions.declaredTypeMustBeUnbound) {
-        Binding.checkUnbound(t, s"t ($t) must be unbound Type. Try using cloneType?")
-      }
-      t.chiselCloneType
-    } else if (next ne null) {
-      (next match {
-        case next: Bits => next.cloneTypeWidth(Width())
-        case _ => next.chiselCloneType
-      }).asInstanceOf[T]
-
-    } else if (init ne null) {
-      init.litArg match {
-        // For e.g. Reg(init=UInt(0, k)), fix the Reg's width to k
-        case Some(lit) if lit.forcedWidth => init.chiselCloneType
-        case _ => (init match {
-          case init: Bits => init.cloneTypeWidth(Width())
-          case _ => init.chiselCloneType
-        }).asInstanceOf[T]
-      }
-    } else {
-      throwException("cannot infer type")
-    }
-  }
-
-  /** Creates a register with optional next and initialization values.
-    *
-    * @param t: data type for the register
-    * @param next: new value register is to be updated with every cycle (or
-    * empty to not update unless assigned to using the := operator)
-    * @param init: initialization value on reset (or empty for uninitialized,
-    * where the register value persists across a reset)
-    *
-    * @note this may result in a type error if called from a type parameterized
-    * function, since the Scala compiler isn't smart enough to know that null
-    * is a valid value. In those cases, you can either use the outType only Reg
-    * constructor or pass in `null.asInstanceOf[T]`.
-    */
-  def apply[T <: Data](t: T = null, next: T = null, init: T = null)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
-    // Scala macros can't (yet) handle named or default arguments.
-    do_apply(t, next, init)(sourceInfo, compileOptions)
-
   /** Creates a register without initialization (reset is ignored). Value does
     * not change unless assigned to (using the := operator).
     *
-    * @param outType: data type for the register
+    * @param t: data type for the register
     */
-  def apply[T <: Data](outType: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = Reg[T](outType, null.asInstanceOf[T], null.asInstanceOf[T])(sourceInfo, compileOptions)
+  def apply[T <: Data](t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+    if (compileOptions.declaredTypeMustBeUnbound) {
+      Binding.checkUnbound(t, s"t ($t) must be unbound Type. Try using cloneType?")
+    }
+    val reg = t.chiselCloneType
+    val clock = Node(Builder.forcedClock)
 
-  def do_apply[T <: Data](t: T, next: T, init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions = chisel3.core.ExplicitCompileOptions.NotStrict): T = {
-    // TODO: write this in a way that doesn't need nulls (bad Scala style),
-    // null.asInstanceOf[T], and two constructors. Using Option types are an
-    // option, but introduces cumbersome syntax (wrap everything in a Some()).
-    // Implicit conversions to Option (or similar) types were also considered,
-    // but Scala's type inferencer and implicit insertion isn't smart enough
-    // to resolve all use cases. If the type inferencer / implicit resolution
-    // system improves, this may be changed.
-    val x = makeType(compileOptions, t, next, init)
+    Binding.bind(reg, RegBinder(Builder.forcedModule), "Error: t")
+    pushCommand(DefReg(sourceInfo, reg, clock))
+    reg
+  }
+}
+
+object RegNext {
+  /** Returns a register with the specified next and no reset initialization.
+    *
+    * Essentially a 1-cycle delayed version of the input signal.
+    */
+  def apply[T <: Data](next: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+    val model = (next match {
+      case next: Bits => next.cloneTypeWidth(Width())
+      case next => next.chiselCloneType
+    }).asInstanceOf[T]
+    val reg = Reg(model)
+
+    Binding.checkSynthesizable(next, s"'next' ($next)")  // TODO: move into connect?
+    reg := next
+
+    reg
+  }
+
+  /** Returns a register with the specified next and reset initialization.
+    *
+    * Essentially a 1-cycle delayed version of the input signal.
+    */
+  def apply[T <: Data](next: T, init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+    val model = (next match {
+      case next: Bits => next.cloneTypeWidth(Width())
+      case next => next.chiselCloneType
+    }).asInstanceOf[T]
+    val reg = RegInit(model, init)  // TODO: this makes NO sense
+
+    Binding.checkSynthesizable(next, s"'next' ($next)")  // TODO: move into connect?
+    reg := next
+
+    reg
+  }
+}
+
+object RegInit {
+  /** Creates a register given an explicit type and an initialization (reset) value.
+    */
+  def apply[T <: Data](t: T, init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+    if (compileOptions.declaredTypeMustBeUnbound) {
+      Binding.checkUnbound(t, s"t ($t) must be unbound Type. Try using cloneType?")
+    }
+    val reg = t.chiselCloneType
     val clock = Node(Builder.forcedClock)
     val reset = Node(Builder.forcedReset)
 
-    // Bind each element of x to being a Reg
-    Binding.bind(x, RegBinder(Builder.forcedModule), "Error: t")
+    Binding.bind(reg, RegBinder(Builder.forcedModule), "Error: t")
+    Binding.checkSynthesizable(init, s"'init' ($init)")
+    pushCommand(DefRegInit(sourceInfo, reg, clock, reset, init.ref))
+    reg
+  }
 
-    if (init == null) {
-      pushCommand(DefReg(sourceInfo, x, clock))
-    } else {
-      Binding.checkSynthesizable(init, s"'init' ($init)")
-      pushCommand(DefRegInit(sourceInfo, x, clock, reset, init.ref))
-    }
-    if (next != null) {
-      Binding.checkSynthesizable(next, s"'next' ($next)")
-      x := next
-    }
-    x
+  /** Returns a register pre-initialized (on reset) to the specified value.
+    * Register type is inferred from the initializer.
+    */
+  def apply[T <: Data](init: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+    val model = (init.litArg match {
+      // For e.g. Reg(init=UInt(0, k)), fix the Reg's width to k
+      case Some(lit) if lit.forcedWidth => init.chiselCloneType
+      case _ => init match {
+        case init: Bits => init.cloneTypeWidth(Width())
+        case init => init.chiselCloneType
+      }
+    }).asInstanceOf[T]
+    RegInit(model, init)
   }
 }

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -27,14 +27,6 @@ trait SourceInfoTransformMacro {
   def implicitCompileOptions = q"implicitly[_root_.chisel3.core.CompileOptions]"
 }
 
-class WireTransform(val c: Context) extends SourceInfoTransformMacro {
-  import c.universe._
-  def apply[T: c.WeakTypeTag](t: c.Tree): c.Tree = {
-    val tpe = weakTypeOf[T]
-    q"$thisObj.do_apply($t, null.asInstanceOf[$tpe])($implicitSourceInfo, $implicitCompileOptions)"
-  }
-}
-
 class UIntTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
   def bitset(off: c.Tree, dat: c.Tree): c.Tree = {
@@ -54,14 +46,6 @@ class MemTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
   def apply[T: c.WeakTypeTag](size: c.Tree, t: c.Tree): c.Tree = {
     q"$thisObj.do_apply($size, $t)($implicitSourceInfo)"
-  }
-}
-
-class RegTransform(val c: Context) extends SourceInfoTransformMacro {
-  import c.universe._
-  def apply[T: c.WeakTypeTag](t: c.Tree): c.Tree = {
-    val tpe = weakTypeOf[T]
-    q"$thisObj.do_apply($t, null.asInstanceOf[$tpe], null.asInstanceOf[$tpe])($implicitSourceInfo)"
   }
 }
 

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -165,7 +165,51 @@ package object Chisel {     // scalastyle:ignore package.object.name
 
   val printf = chisel3.core.printf
 
-  val Reg = chisel3.core.Reg
+  val RegNext = chisel3.core.RegNext
+  val RegInit = chisel3.core.RegInit
+  object Reg {
+    import chisel3.core.{Binding, CompileOptions}
+    import chisel3.internal.sourceinfo.SourceInfo
+
+    /** Creates a register with optional next and initialization values.
+      *
+      * @param t: data type for the register
+      * @param next: new value register is to be updated with every cycle (or
+      * empty to not update unless assigned to using the := operator)
+      * @param init: initialization value on reset (or empty for uninitialized,
+      * where the register value persists across a reset)
+      *
+      * @note this may result in a type error if called from a type parameterized
+      * function, since the Scala compiler isn't smart enough to know that null
+      * is a valid value. In those cases, you can either use the outType only Reg
+      * constructor or pass in `null.asInstanceOf[T]`.
+      */
+    def apply[T <: Data](t: T = null, next: T = null, init: T = null)
+        (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+      if (t ne null) {
+        val reg = if (init ne null) {
+          RegInit(t, init)
+        } else {
+          chisel3.core.Reg(t)
+        }
+        if (next ne null) {
+          Binding.checkSynthesizable(next, s"'next' ($next)")  // TODO: move into connect?
+          reg := next
+        }
+        reg
+      } else if (next ne null) {
+        if (init ne null) {
+          RegNext(next, init)
+        } else {
+          RegNext(next)
+        }
+      } else if (init ne null) {
+        RegInit(init)
+      } else {
+        throwException("cannot infer type")
+      }
+    }
+  }
 
   val when = chisel3.core.when
   type WhenContext = chisel3.core.WhenContext
@@ -340,8 +384,6 @@ package object Chisel {     // scalastyle:ignore package.object.name
   val UIntToOH = chisel3.util.UIntToOH
   val PriorityEncoderOH = chisel3.util.PriorityEncoderOH
 
-  val RegNext = chisel3.util.RegNext
-  val RegInit = chisel3.util.RegInit
   val RegEnable = chisel3.util.RegEnable
   val ShiftRegister = chisel3.util.ShiftRegister
 

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -155,7 +155,45 @@ package object chisel3 {    // scalastyle:ignore package.object.name
 
   val printf = chisel3.core.printf
 
-  val Reg = chisel3.core.Reg
+  val RegNext = chisel3.core.RegNext
+  val RegInit = chisel3.core.RegInit
+  object Reg {
+    import chisel3.core.{Binding, CompileOptions}
+    import chisel3.internal.sourceinfo.SourceInfo
+    import chisel3.internal.throwException
+
+    // Passthrough for chisel3.core.Reg
+    // TODO: make val Reg = chisel3.core.Reg once we eliminate the legacy Reg constructor
+    def apply[T <: Data](t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
+      chisel3.core.Reg(t)
+
+    @deprecated("Use Reg(t), RegNext(next, [init]) or RegInit([t], init) instead", "chisel3")
+    def apply[T <: Data](t: T = null, next: T = null, init: T = null)
+        (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+      if (t ne null) {
+        val reg = if (init ne null) {
+          RegInit(t, init)
+        } else {
+          chisel3.core.Reg(t)
+        }
+        if (next ne null) {
+          Binding.checkSynthesizable(next, s"'next' ($next)")  // TODO: move into connect?
+          reg := next
+        }
+        reg
+      } else if (next ne null) {
+        if (init ne null) {
+          RegNext(next, init)
+        } else {
+          RegNext(next)
+        }
+      } else if (init ne null) {
+        RegInit(init)
+      } else {
+        throwException("cannot infer type")
+      }
+    }
+  }
 
   val when = chisel3.core.when
   type WhenContext = chisel3.core.WhenContext

--- a/src/main/scala/chisel3/util/Counter.scala
+++ b/src/main/scala/chisel3/util/Counter.scala
@@ -14,7 +14,7 @@ import chisel3.internal.naming.chiselName  // can't use chisel3_ version because
 @chiselName
 class Counter(val n: Int) {
   require(n >= 0)
-  val value = if (n > 1) Reg(init=0.U(log2Ceil(n).W)) else 0.U
+  val value = if (n > 1) RegInit(0.U(log2Ceil(n).W)) else 0.U
 
   /** Increment the counter, returning whether the counter currently is at the
     * maximum and will wrap. The incremented value is registered and will be

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -182,7 +182,7 @@ extends Module(override_reset=override_reset) {
   private val ram = Mem(entries, gen)
   private val enq_ptr = Counter(entries)
   private val deq_ptr = Counter(entries)
-  private val maybe_full = Reg(init=false.B)
+  private val maybe_full = RegInit(false.B)
 
   private val ptr_match = enq_ptr.value === deq_ptr.value
   private val empty = ptr_match && !maybe_full

--- a/src/main/scala/chisel3/util/LFSR.scala
+++ b/src/main/scala/chisel3/util/LFSR.scala
@@ -19,7 +19,7 @@ object LFSR16 {
   @chiselName
   def apply(increment: Bool = true.B): UInt = {
     val width = 16
-    val lfsr = Reg(init=1.U(width.W))
+    val lfsr = RegInit(1.U(width.W))
     when (increment) { lfsr := Cat(lfsr(0)^lfsr(2)^lfsr(3)^lfsr(5), lfsr(width-1,1)) }
     lfsr
   }

--- a/src/main/scala/chisel3/util/Reg.scala
+++ b/src/main/scala/chisel3/util/Reg.scala
@@ -6,41 +6,21 @@ import chisel3._
 // TODO: remove this once we have CompileOptions threaded through the macro system.
 import chisel3.core.ExplicitCompileOptions.NotStrict
 
-object RegNext {
-  /** Returns a register with the specified next and no reset initialization.
-    *
-    * Essentially a 1-cycle delayed version of the input signal.
-    */
-  def apply[T <: Data](next: T): T = Reg[T](null.asInstanceOf[T], next, null.asInstanceOf[T])
-
-  /** Returns a register with the specified next and reset initialization.
-    *
-    * Essentially a 1-cycle delayed version of the input signal.
-    */
-  def apply[T <: Data](next: T, init: T): T = Reg[T](null.asInstanceOf[T], next, init)
-}
-
-object RegInit {
-  /** Returns a register pre-initialized (on reset) to the specified value.
-    */
-  def apply[T <: Data](init: T): T = Reg[T](null.asInstanceOf[T], null.asInstanceOf[T], init)
-}
-
 object RegEnable {
   /** Returns a register with the specified next, update enable gate, and no reset initialization.
     */
-  def apply[T <: Data](updateData: T, enable: Bool): T = {
-    val clonedUpdateData = updateData.chiselCloneType
-    val r = Reg(clonedUpdateData)
-    when (enable) { r := updateData }
+  def apply[T <: Data](next: T, enable: Bool): T = {
+    val clonedNext = next.chiselCloneType
+    val r = Reg(clonedNext)
+    when (enable) { r := next }
     r
   }
 
   /** Returns a register with the specified next, update enable gate, and reset initialization.
     */
-  def apply[T <: Data](updateData: T, resetData: T, enable: Bool): T = {
-    val r = RegInit(resetData)
-    when (enable) { r := updateData }
+  def apply[T <: Data](next: T, init: T, enable: Bool): T = {
+    val r = RegInit(init)
+    when (enable) { r := next }
     r
   }
 }

--- a/src/main/scala/chisel3/util/Valid.scala
+++ b/src/main/scala/chisel3/util/Valid.scala
@@ -44,7 +44,7 @@ object Pipe
       out.bits <> enqBits
       out
     } else {
-      val v = Reg(Bool(), next=enqValid, init=false.B)
+      val v = RegNext(enqValid, false.B)
       val b = RegEnable(enqBits, enqValid)
       apply(v, b, latency-1)
     }

--- a/src/test/scala/chiselTests/Assert.scala
+++ b/src/test/scala/chiselTests/Assert.scala
@@ -27,8 +27,8 @@ class SucceedingAssertTester() extends BasicTester {
 
 class PipelinedResetModule extends Module {
   val io = IO(new Bundle { })
-  val a = Reg(init = 0xbeef.U)
-  val b = Reg(init = 0xbeef.U)
+  val a = RegInit(0xbeef.U)
+  val b = RegInit(0xbeef.U)
   assert(a === b)
 }
 
@@ -36,7 +36,7 @@ class PipelinedResetModule extends Module {
 class PipelinedResetTester extends BasicTester {
   val module = Module(new PipelinedResetModule)
 
-  module.reset := Reg(next = Reg(next = Reg(next = reset)))
+  module.reset := RegNext(RegNext(RegNext(reset)))
 
   val (_, done) = Counter(!reset, 4)
   when (done) {

--- a/src/test/scala/chiselTests/Counter.scala
+++ b/src/test/scala/chiselTests/Counter.scala
@@ -18,7 +18,7 @@ class CountTester(max: Int) extends BasicTester {
 }
 
 class EnableTester(seed: Int) extends BasicTester {
-  val ens = Reg(init = seed.asUInt)
+  val ens = RegInit(seed.asUInt)
   ens := ens >> 1
 
   val (cntEnVal, _) = Counter(ens(0), 32)

--- a/src/test/scala/chiselTests/EnableShiftRegister.scala
+++ b/src/test/scala/chiselTests/EnableShiftRegister.scala
@@ -10,10 +10,10 @@ class EnableShiftRegister extends Module {
     val shift = Input(Bool())
     val out   = Output(UInt(4.W))
   })
-  val r0 = Reg(init = 0.U(4.W))
-  val r1 = Reg(init = 0.U(4.W))
-  val r2 = Reg(init = 0.U(4.W))
-  val r3 = Reg(init = 0.U(4.W))
+  val r0 = RegInit(0.U(4.W))
+  val r1 = RegInit(0.U(4.W))
+  val r2 = RegInit(0.U(4.W))
+  val r3 = RegInit(0.U(4.W))
   when(io.shift) {
     r0 := io.in
     r1 := r0

--- a/src/test/scala/chiselTests/GCD.scala
+++ b/src/test/scala/chiselTests/GCD.scala
@@ -26,7 +26,7 @@ class GCD extends Module {
 
 class GCDTester(a: Int, b: Int, z: Int) extends BasicTester {
   val dut = Module(new GCD)
-  val first = Reg(init=true.B)
+  val first = RegInit(true.B)
   dut.io.a := a.U
   dut.io.b := b.U
   dut.io.e := first

--- a/src/test/scala/chiselTests/LFSR16.scala
+++ b/src/test/scala/chiselTests/LFSR16.scala
@@ -11,7 +11,7 @@ class LFSR16 extends Module {
     val inc = Input(Bool())
     val out = Output(UInt(16.W))
   })
-  val res = Reg(init = 1.U(16.W))
+  val res = RegInit(1.U(16.W))
   when (io.inc) {
     val nxt_res = Cat(res(0)^res(2)^res(3)^res(5), res(15,1))
     res := nxt_res

--- a/src/test/scala/chiselTests/MemorySearch.scala
+++ b/src/test/scala/chiselTests/MemorySearch.scala
@@ -13,7 +13,7 @@ class MemorySearch extends Module {
     val address = Output(UInt(3.W))
   })
   val vals  = Array(0, 4, 15, 14, 2, 5, 13)
-  val index = Reg(init = 0.U(3.W))
+  val index = RegInit(0.U(3.W))
   val elts  = Vec(vals.map(_.asUInt(4.W)))
   // val elts  = Mem(UInt(32.W), 8) TODO ????
   val elt  = elts(index)

--- a/src/test/scala/chiselTests/MultiClockSpec.scala
+++ b/src/test/scala/chiselTests/MultiClockSpec.scala
@@ -4,7 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental.{withClockAndReset, withClock, withReset}
-import chisel3.util.{Counter, RegInit}
+import chisel3.util.{Counter}
 import chisel3.testers.BasicTester
 
 /** Multi-clock test of a Reg using a different clock via withClock */

--- a/src/test/scala/chiselTests/MultiClockSpec.scala
+++ b/src/test/scala/chiselTests/MultiClockSpec.scala
@@ -4,7 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental.{withClockAndReset, withClock, withReset}
-import chisel3.util.{Counter}
+import chisel3.util.Counter
 import chisel3.testers.BasicTester
 
 /** Multi-clock test of a Reg using a different clock via withClock */

--- a/src/test/scala/chiselTests/Reg.scala
+++ b/src/test/scala/chiselTests/Reg.scala
@@ -11,39 +11,32 @@ import chisel3.core.DataMirror
 import chisel3.testers.BasicTester
 
 class RegSpec extends ChiselFlatSpec {
-  "A Reg" should "throw an exception if not given any parameters" in {
-    a [Exception] should be thrownBy {
-      val reg = Reg()
-    }
-  }
-
-  "A Reg" should "be of the same type and width as outType, if specified" in {
+  "Reg" should "be of the same type and width as t" in {
     class RegOutTypeWidthTester extends BasicTester {
-      val reg = Reg(t=UInt(2.W), next=Wire(UInt(3.W)), init=20.U)
-      reg.getWidth should be (2)
+      val reg = Reg(UInt(2.W))
+      DataMirror.widthOf(reg) should be (2.W)
     }
     elaborate{ new RegOutTypeWidthTester }
   }
 
-  "A Reg" should "be of unknown width if outType is not specified and width is not forced" in {
+  "RegNext" should "be of unknown width" in {
     class RegUnknownWidthTester extends BasicTester {
-      val reg1 = Reg(next=Wire(UInt(3.W)), init=20.U)
-      reg1.isWidthKnown should be (false)
+      val reg1 = RegNext(2.U(3.W))
       DataMirror.widthOf(reg1).known should be (false)
-      val reg2 = Reg(init=20.U)
-      reg2.isWidthKnown should be (false)
+      val reg2 = RegNext(2.U(3.W), 4.U)
       DataMirror.widthOf(reg2).known should be (false)
-      val reg3 = Reg(next=Wire(UInt(3.W)), init=5.U)
-      reg3.isWidthKnown should be (false)
+      val reg3 = RegNext(2.U(3.W), 4.U(5.W))
       DataMirror.widthOf(reg3).known should be (false)
     }
     elaborate { new RegUnknownWidthTester }
   }
 
-  "A Reg" should "be of width of init if outType and next are missing and init is a literal of forced width" in {
+  "RegInit" should "have width only if specified in the literal" in {
     class RegForcedWidthTester extends BasicTester {
-      val reg2 = Reg(init=20.U(7.W))
-      reg2.getWidth should be (7)
+      val reg1 = RegInit(20.U)
+      DataMirror.widthOf(reg1).known should be (false)
+      val reg2 = RegInit(20.U(7.W))
+      DataMirror.widthOf(reg2) should be (7.W)
     }
     elaborate{ new RegForcedWidthTester }
   }

--- a/src/test/scala/chiselTests/Risc.scala
+++ b/src/test/scala/chiselTests/Risc.scala
@@ -17,7 +17,7 @@ class Risc extends Module {
   val memSize = 256
   val file = Mem(memSize, Bits(32.W))
   val code = Mem(memSize, Bits(32.W))
-  val pc   = Reg(init=0.U(8.W))
+  val pc   = RegInit(0.U(8.W))
 
   val add_op :: imm_op :: Nil = Enum(2)
 

--- a/src/test/scala/chiselTests/Stack.scala
+++ b/src/test/scala/chiselTests/Stack.scala
@@ -17,8 +17,8 @@ class ChiselStack(val depth: Int) extends Module {
   })
 
   val stack_mem = Mem(depth, UInt(32.W))
-  val sp        = Reg(init = 0.U(log2Ceil(depth+1).W))
-  val out       = Reg(init = 0.U(32.W))
+  val sp        = RegInit(0.U(log2Ceil(depth+1).W))
+  val out       = RegInit(0.U(32.W))
 
   when (io.en) {
     when(io.push && (sp < depth.asUInt)) {

--- a/src/test/scala/chiselTests/Stop.scala
+++ b/src/test/scala/chiselTests/Stop.scala
@@ -11,7 +11,7 @@ class StopTester() extends BasicTester {
 }
 
 class StopImmediatelyTester extends BasicTester {
-  val cycle = Reg(init = 0.asUInt(4.W))
+  val cycle = RegInit(0.asUInt(4.W))
   cycle := cycle + 1.U
   when (cycle === 4.U) {
     stop()

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -20,7 +20,7 @@ class RegTesterMod(vecSize: Int) extends Module {
     val in = Input(Vec(vecSize, UInt()))
     val out = Output(Vec(vecSize, UInt()))
   })
-  val vecReg = Reg(init = Vec(vecSize, 0.U), next = io.in)
+  val vecReg = RegNext(io.in, Vec(vecSize, 0.U))
   io.out := vecReg
 }
 

--- a/src/test/scala/cookbook/FSM.scala
+++ b/src/test/scala/cookbook/FSM.scala
@@ -17,7 +17,7 @@ class DetectTwoOnes extends Module {
   })
 
   val sNone :: sOne1 :: sTwo1s :: Nil = Enum(3)
-  val state = Reg(init = sNone)
+  val state = RegInit(sNone)
 
   io.out := (state === sTwo1s)
 

--- a/src/test/scala/cookbook/RegOfVec.scala
+++ b/src/test/scala/cookbook/RegOfVec.scala
@@ -19,7 +19,7 @@ class RegOfVec extends CookbookTester(2) {
   //   Note that Seq.fill constructs 4 32-bit UInt literals with the value 0
   //   Vec(...) then constructs a Wire of these literals
   //   The Reg is then initialized to the value of the Wire (which gives it the same type)
-  val initRegOfVec = Reg(init = Vec(Seq.fill(4)(0.asUInt(32.W))))
+  val initRegOfVec = RegInit(Vec(Seq.fill(4)(0.asUInt(32.W))))
 
   // Simple test (cycle comes from superclass)
   when (cycle === 2.U) { assert(regOfVec(2) === 123.U) }

--- a/src/test/scala/cookbook/RegOfVec.scala
+++ b/src/test/scala/cookbook/RegOfVec.scala
@@ -19,7 +19,7 @@ class RegOfVec extends CookbookTester(2) {
   //   Note that Seq.fill constructs 4 32-bit UInt literals with the value 0
   //   Vec(...) then constructs a Wire of these literals
   //   The Reg is then initialized to the value of the Wire (which gives it the same type)
-  val initRegOfVec = RegInit(Vec(Seq.fill(4)(0.asUInt(32.W))))
+  val initRegOfVec = RegInit(Vec(Seq.fill(4)(0.U(32.W))))
 
   // Simple test (cycle comes from superclass)
   when (cycle === 2.U) { assert(regOfVec(2) === 123.U) }

--- a/src/test/scala/examples/ImplicitStateVendingMachine.scala
+++ b/src/test/scala/examples/ImplicitStateVendingMachine.scala
@@ -8,7 +8,7 @@ import chisel3._
 // Vending machine implemented with an implicit state machine
 class ImplicitStateVendingMachine extends SimpleVendingMachine {
   // We let the value of nickel be 1 and dime be 2 for efficiency reasons
-  val value = Reg(init = 0.asUInt(3.W))
+  val value = RegInit(0.asUInt(3.W))
   val incValue = Wire(init = 0.asUInt(3.W))
   val doDispense = value >= 4.U // 4 * nickel as 1 == $0.20
 

--- a/src/test/scala/examples/SimpleVendingMachine.scala
+++ b/src/test/scala/examples/SimpleVendingMachine.scala
@@ -22,7 +22,7 @@ abstract class SimpleVendingMachine extends Module {
 // Vending machine implemented with a Finite State Machine
 class FSMVendingMachine extends SimpleVendingMachine {
   val sIdle :: s5 :: s10 :: s15 :: sOk :: Nil = Enum(5)
-  val state = Reg(init = sIdle)
+  val state = RegInit(sIdle)
 
   switch (state) {
     is (sIdle) {

--- a/src/test/scala/examples/VendingMachineGenerator.scala
+++ b/src/test/scala/examples/VendingMachineGenerator.scala
@@ -53,7 +53,7 @@ class VendingMachineGenerator(
   val maxValue = (sodaCost + maxCoin - minCoin) / minCoin // normalize to minimum value
 
   val width = log2Ceil(maxValue + 1).W
-  val value = Reg(init = 0.asUInt(width))
+  val value = RegInit(0.asUInt(width))
   val incValue = Wire(init = 0.asUInt(width))
   val doDispense = value >= (sodaCost / minCoin).U
 


### PR DESCRIPTION
*cleaning up Chisel, removing null at a time*

Implementation for resolution in #438. With some clean-up in Wire, eliminating more nulls.

Up for debate is a Reg constructor with an explicit model and init, which isn't supported under RegNext/RegInit. I just did Reg.Init for now, but feel free to come up with a better API. Conceptually, Reg creates a type with explicit model, and its Init variant allows an optional initializer. Specifying init after the Reg is declared would not be easy to implement.

Also for consideration is Reg semantics. For compatibility reasons, if next and init are defined (here: RegNext(next, init)), the resulting model type has no width, but is init is defined without next, the resulting mode type has width in init, but only if it is explicitly specified. The rule is a mouthful, and the next no width prioritization seems nonsensical. I'd advocate for init-derived width to take priority. And perhaps a better (internal) API for getting model from an init, since that is also re-used in Wire.