### PR TITLE
doesn't lose old firrtl options annotations + transforms

### DIFF
--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -256,8 +256,8 @@ object Driver extends BackendCompilationUtilities {
     /* This passes the firrtl source and annotations directly to firrtl */
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(
       firrtlSource = Some(firrtlString),
-      annotations = circuit.annotations.toList,
-      customTransforms = transforms.toList)
+      annotations = optionsManager.firrtlOptions.annotations ++ circuit.annotations.toList,
+      customTransforms = optionsManager.firrtlOptions.customTransforms ++ transforms.toList)
 
     val firrtlExecutionResult = if(chiselOptions.runFirrtlCompiler) {
       Some(firrtl.Driver.execute(optionsManager))


### PR DESCRIPTION
Problem: For Driver.execute, when you tried passing transforms/annotations via FirrtlOptions, they'd get overwritten before they ever got to Firrtl. Now I'm just appending the new stuff to what was already there...

Execution options are really hairy and poorly maintained across the various levels of Chisel hierarchy...