### PR TITLE
Fix namespace

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -374,7 +374,10 @@ abstract class Record extends Aggregate {
 
   // NOTE: This sets up dependent references, it can be done before closing the Module
   private[chisel3] override def _onModuleClose: Unit = { // scalastyle:ignore method.name
-    val _namespace = Builder.globalNamespace.child
+    // Since Bundle names this via reflection, it is impossible for two elements to have the same
+    // identifier; however, Namespace sanitizes identifiers to make them legal for Firrtl/Verilog
+    // which can cause collisions
+    val _namespace = Namespace.empty
     for ((name, elt) <- elements) { elt.setRef(this, _namespace.name(name)) }
   }
 

--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -113,7 +113,8 @@ extends HasId {
     Port(iodef)
   }
 
-  private[core] val _namespace = Builder.globalNamespace.child
+  // Fresh Namespace because in Firrtl, Modules namespaces are disjoint with the global namespace
+  private[core] val _namespace = Namespace.empty
   private[chisel3] val _commands = ArrayBuffer[Command]()
   private[core] val _ids = ArrayBuffer[HasId]()
   Builder.currentModule = Some(this)
@@ -210,7 +211,7 @@ extends HasId {
 
     // For Module instances we haven't named, suggest the name of the Module
     _ids foreach {
-      case m: Module => m.suggestName(m.name)
+      case m: Module => m.suggestName(m.desiredName)
       case _ =>
     }
 

--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -9,7 +9,7 @@ import chisel3._
 import core._
 import firrtl._
 
-private[chisel3] class Namespace(parent: Option[Namespace], keywords: Set[String]) {
+private[chisel3] class Namespace(keywords: Set[String]) {
   private val names = collection.mutable.HashMap[String, Long]()
   for (keyword <- keywords)
     names(keyword) = 1
@@ -29,9 +29,7 @@ private[chisel3] class Namespace(parent: Option[Namespace], keywords: Set[String
     if (res.isEmpty || !legalStart(res.head)) s"_$res" else res
   }
 
-  def contains(elem: String): Boolean = {
-    names.contains(elem) || parent.map(_ contains elem).getOrElse(false)
-  }
+  def contains(elem: String): Boolean = names.contains(elem)
 
   def name(elem: String): String = {
     val sanitized = sanitize(elem)
@@ -42,9 +40,11 @@ private[chisel3] class Namespace(parent: Option[Namespace], keywords: Set[String
       sanitized
     }
   }
+}
 
-  def child(kws: Set[String]): Namespace = new Namespace(Some(this), kws)
-  def child: Namespace = child(Set())
+private[chisel3] object Namespace {
+  /** Constructs an empty Namespace */
+  def empty: Namespace = new Namespace(Set.empty[String])
 }
 
 private[chisel3] class IdGen {
@@ -143,7 +143,7 @@ private[chisel3] trait HasId extends InstanceId {
 
 private[chisel3] class DynamicContext() {
   val idGen = new IdGen
-  val globalNamespace = new Namespace(None, Set())
+  val globalNamespace = Namespace.empty
   val components = ArrayBuffer[Component]()
   val annotations = ArrayBuffer[ChiselAnnotation]()
   var currentModule: Option[Module] = None

--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -182,7 +182,7 @@ trait ChiselExecutionResult
   * @param emitted            The emitted Chirrrl text
   * @param firrtlResultOption Optional Firrtl result, @see ucb-bar/firrtl for details
   */
-case class ChiselExecutionSucccess(
+case class ChiselExecutionSuccess(
                                   circuitOption: Option[Circuit],
                                   emitted: String,
                                   firrtlResultOption: Option[FirrtlExecutionResult]
@@ -277,7 +277,7 @@ object Driver extends BackendCompilationUtilities {
     else {
       None
     }
-    ChiselExecutionSucccess(Some(circuit), firrtlString, firrtlExecutionResult)
+    ChiselExecutionSuccess(Some(circuit), firrtlString, firrtlExecutionResult)
   }
 
   /**

--- a/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
+++ b/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
@@ -143,7 +143,7 @@ class AnnotatingDiamondSpec extends FreeSpec with Matchers {
       |that happens only after emit has been called on circuit""".stripMargin in {
 
       Driver.execute(Array.empty[String], () => new TopOfDiamond) match {
-        case ChiselExecutionSucccess(Some(circuit), emitted, _) =>
+        case ChiselExecutionSuccess(Some(circuit), emitted, _) =>
           val annos = circuit.annotations
           annos.length should be (10)
 

--- a/src/test/scala/chiselTests/AnnotationNoDedup.scala
+++ b/src/test/scala/chiselTests/AnnotationNoDedup.scala
@@ -51,7 +51,7 @@ class AnnotationNoDedup extends FreeSpec with Matchers {
   "Firrtl provides transform that reduces identical modules to a single instance" - {
     "Annotations can be added which will defeat this deduplication for specific modules instances" in {
       Driver.execute(Array("-X", "low"), () => new UsesMuchUsedModule(addAnnos = true)) match {
-        case ChiselExecutionSucccess(_, _, Some(firrtlResult: FirrtlExecutionSuccess)) =>
+        case ChiselExecutionSuccess(_, _, Some(firrtlResult: FirrtlExecutionSuccess)) =>
           val lowFirrtl = firrtlResult.emitted
 
           lowFirrtl should include ("module MuchUsedModule :")
@@ -64,7 +64,7 @@ class AnnotationNoDedup extends FreeSpec with Matchers {
     }
     "Turning off these nnotations dedup all the occurrences" in {
       Driver.execute(Array("-X", "low"), () => new UsesMuchUsedModule(addAnnos = false)) match {
-        case ChiselExecutionSucccess(_, _, Some(firrtlResult: FirrtlExecutionSuccess)) =>
+        case ChiselExecutionSuccess(_, _, Some(firrtlResult: FirrtlExecutionSuccess)) =>
           val lowFirrtl = firrtlResult.emitted
 
           lowFirrtl should include ("module MuchUsedModule :")

--- a/src/test/scala/chiselTests/BlackBoxImpl.scala
+++ b/src/test/scala/chiselTests/BlackBoxImpl.scala
@@ -68,7 +68,7 @@ class BlackBoxImplSpec extends FreeSpec with Matchers {
   "BlackBox can have verilator source implementation" - {
     "Implementations can be contained in-line" in {
       Driver.execute(Array("-X", "verilog"), () => new UsesBlackBoxAddViaInline) match {
-        case ChiselExecutionSucccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
+        case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
           val verilogOutput = new File("./BlackBoxAdd.v")
           verilogOutput.exists() should be (true)
           verilogOutput.delete()
@@ -79,7 +79,7 @@ class BlackBoxImplSpec extends FreeSpec with Matchers {
     }
     "Implementations can be contained in resource files" in {
       Driver.execute(Array("-X", "low"), () => new UsesBlackBoxMinusViaResource) match {
-        case ChiselExecutionSucccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
+        case ChiselExecutionSuccess(_, _, Some(_: FirrtlExecutionSuccess)) =>
           val verilogOutput = new File("./BlackBoxTest.v")
           verilogOutput.exists() should be (true)
           verilogOutput.delete()

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -8,6 +8,12 @@ import org.scalatest.prop._
 import org.scalacheck._
 import chisel3._
 import chisel3.testers._
+import firrtl.{
+  ExecutionOptionsManager,
+  HasFirrtlOptions,
+  FirrtlExecutionSuccess,
+  FirrtlExecutionFailure
+}
 
 /** Common utility functions for Chisel unit tests. */
 trait ChiselRunners extends Assertions {
@@ -21,7 +27,20 @@ trait ChiselRunners extends Assertions {
     assert(!runTester(t, additionalVResources))
   }
   def elaborate(t: => Module): Unit = Driver.elaborate(() => t)
-
+  /** Compiles a Chisel Module to Verilog */
+  def compile(t: => Module): String = {
+    val manager = new ExecutionOptionsManager("compile") with HasFirrtlOptions
+                                                         with HasChiselExecutionOptions
+    Driver.execute(manager, () => t) match {
+      case ChiselExecutionSuccess(_, _, Some(firrtlExecRes)) =>
+        firrtlExecRes match {
+          case FirrtlExecutionSuccess(_, verilog) => verilog
+          case FirrtlExecutionFailure(msg) => fail(msg)
+        }
+      case ChiselExecutionSuccess(_, _, None) => fail() // This shouldn't happen
+      case ChiselExecutionFailure(msg) => fail(msg)
+    }
+  }
 }
 
 /** Spec base class for BDD-style testers. */

--- a/src/test/scala/chiselTests/DedupSpec.scala
+++ b/src/test/scala/chiselTests/DedupSpec.scala
@@ -1,0 +1,57 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.util._
+
+class DedupIO extends Bundle {
+  val in = Flipped(Decoupled(UInt(32.W)))
+  val out = Decoupled(UInt(32.W))
+}
+
+class DedupQueues(n: Int) extends Module {
+  require(n > 0)
+  val io = IO(new DedupIO)
+  val queues = Seq.fill(n)(Module(new Queue(UInt(32.W), 4)))
+  var port = io.in
+  for (q <- queues) {
+    q.io.enq <> port
+    port = q.io.deq
+  }
+  io.out <> port
+}
+
+/* This module creates a Queue in a nested function (such that it is not named via reflection). The
+ * default naming for instances prior to #470 caused otherwise identical instantiations of this
+ * module to have different instance names for the queues which prevented deduplication.
+ * NestedDedup instantiates this module twice to ensure it is deduplicated properly.
+ */
+class DedupSubModule extends Module {
+  val io = IO(new DedupIO)
+  io.out <> Queue(io.in, 4)
+}
+
+class NestedDedup extends Module {
+  val io = IO(new DedupIO)
+  val inst0 = Module(new DedupSubModule)
+  val inst1 = Module(new DedupSubModule)
+  inst0.io.in <> io.in
+  inst1.io.in <> inst0.io.out
+  io.out <> inst1.io.out
+}
+
+class DedupSpec extends ChiselFlatSpec {
+  private val ModuleRegex = """\s*module\s+(\w+)\b.*""".r
+  def countModules(verilog: String): Int =
+    (verilog split "\n"  collect { case ModuleRegex(name) => name }).size
+
+  "Deduplication" should "occur" in {
+    assert(countModules(compile { new DedupQueues(4) }) === 2)
+  }
+
+  it should "properly dedup modules with deduped submodules" in {
+    assert(countModules(compile { new NestedDedup }) === 3)
+  }
+}
+

--- a/src/test/scala/chiselTests/DriverSpec.scala
+++ b/src/test/scala/chiselTests/DriverSpec.scala
@@ -25,8 +25,8 @@ class DriverSpec extends FreeSpec with Matchers {
     "execute returns a chisel execution result" in {
       val args = Array("--compiler", "low")
       val result = Driver.execute(Array.empty[String], () => new DummyModule)
-      result shouldBe a[ChiselExecutionSucccess]
-      val successResult = result.asInstanceOf[ChiselExecutionSucccess]
+      result shouldBe a[ChiselExecutionSuccess]
+      val successResult = result.asInstanceOf[ChiselExecutionSuccess]
       successResult.emitted should include ("circuit DummyModule")
     }
   }


### PR DESCRIPTION
Fixing one subtle bug led me to another which led to this fix (and a couple of minor other improvements). As all 3 commits are kind of orthogonal, I request a rebase and merge rather than squash.

Copy-paste most important commit message here:

Make Module and Bundle properly use empty namespaces
Also fix default suggested name of Module instances (now based on desired name
rather than actual assigned name).

Previously, Module and Bundle namespaces were "children" of the Module
definition namespace. This could lead to collisions that would give unexpected
names for module instances or Bundle elements. In particular, otherwise
identical modules that instantiate other identical modules in such a way that
the instance cannot be named via reflection would not be deduplicated because
the names of the instances would collide with the names of the modules in the
Builder.globalNamespace.