### PR TITLE
Don't allow CompileOptions to materialize in Chisel core

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/CompileOptions.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/CompileOptions.scala
@@ -3,6 +3,7 @@
 package chisel3.core
 
 import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
 
 trait CompileOptions {
   // Should Record connections require a strict match of fields.
@@ -26,7 +27,13 @@ trait CompileOptions {
 
 object CompileOptions {
   // Provides a low priority Strict default. Can be overridden by importing the NotStrict option.
-  implicit def materialize: CompileOptions = chisel3.core.ExplicitCompileOptions.Strict
+  // Implemented as a macro to prevent this from being used inside chisel core.
+  implicit def materialize: CompileOptions = macro materialize_impl
+
+  def materialize_impl(c: Context): c.Tree = {
+    import c.universe._
+    q"_root_.chisel3.core.ExplicitCompileOptions.Strict"
+  }
 }
 
 object ExplicitCompileOptions {


### PR DESCRIPTION
Implemented using macros.

The implicit needs to be defined low priority in the resolution order (https://stackoverflow.com/questions/5598085/where-does-scala-look-for-implicits) so that the user could overload it (instead of triggering an ambiguous implicit error). The companion object must be defined in the same source file (so we can't move the definition to the chisel3 package, for instance) so this relies on what is an implementation limitation of the Scala macro system.

Implementation for #460