### PR TITLE
Add naming transforms to chisel utils

### DIFF
--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -345,20 +345,10 @@ package object Chisel {     // scalastyle:ignore package.object.name
     * non-experimental, you must explicitly import this package to use its contents.
     */
   object experimental {
-    import scala.annotation.StaticAnnotation
     import scala.annotation.compileTimeOnly
 
-    @compileTimeOnly("enable macro paradise to expand macro annotations")
-    class dump extends StaticAnnotation {
-      def macroTransform(annottees: Any*): Any = macro chisel3.internal.naming.DebugTransforms.dump
-    }
-    @compileTimeOnly("enable macro paradise to expand macro annotations")
-    class treedump extends StaticAnnotation {
-      def macroTransform(annottees: Any*): Any = macro chisel3.internal.naming.DebugTransforms.treedump
-    }
-    @compileTimeOnly("enable macro paradise to expand macro annotations")
-    class chiselName extends StaticAnnotation {
-      def macroTransform(annottees: Any*): Any = macro chisel3.internal.naming.NamingTransforms.chiselName
-    }
+    class dump extends chisel3.internal.naming.dump
+    class treedump extends chisel3.internal.naming.treedump
+    class chiselName extends chisel3.internal.naming.chiselName
   }
 }

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -293,21 +293,10 @@ package object chisel3 {    // scalastyle:ignore package.object.name
       def range(args: Any*): (NumericBound[Int], NumericBound[Int]) = macro chisel3.internal.RangeTransform.apply
     }
 
-    import scala.language.experimental.macros
-    import scala.annotation.StaticAnnotation
     import scala.annotation.compileTimeOnly
 
-    @compileTimeOnly("enable macro paradise to expand macro annotations")
-    class dump extends StaticAnnotation {
-      def macroTransform(annottees: Any*): Any = macro chisel3.internal.naming.DebugTransforms.dump
-    }
-    @compileTimeOnly("enable macro paradise to expand macro annotations")
-    class treedump extends StaticAnnotation {
-      def macroTransform(annottees: Any*): Any = macro chisel3.internal.naming.DebugTransforms.treedump
-    }
-    @compileTimeOnly("enable macro paradise to expand macro annotations")
-    class chiselName extends StaticAnnotation {
-      def macroTransform(annottees: Any*): Any = macro chisel3.internal.naming.NamingTransforms.chiselName
-    }
+    class dump extends chisel3.internal.naming.dump
+    class treedump extends chisel3.internal.naming.treedump
+    class chiselName extends chisel3.internal.naming.chiselName
   }
 }

--- a/src/main/scala/chisel3/util/Arbiter.scala
+++ b/src/main/scala/chisel3/util/Arbiter.scala
@@ -6,6 +6,7 @@
 package chisel3.util
 
 import chisel3._
+import chisel3.internal.naming.chiselName  // can't use chisel3_ version because of compile order
 // TODO: remove this once we have CompileOptions threaded through the macro system.
 import chisel3.core.ExplicitCompileOptions.NotStrict
 
@@ -97,6 +98,7 @@ class LockingArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T 
   * consumer.io.in <> arb.io.out
   * }}}
   */
+@chiselName
 class RRArbiter[T <: Data](gen:T, n: Int) extends LockingRRArbiter[T](gen, n, 1)
 
 /** Hardware module that is used to sequence n producers into 1 consumer.
@@ -109,6 +111,7 @@ class RRArbiter[T <: Data](gen:T, n: Int) extends LockingRRArbiter[T](gen, n, 1)
   * consumer.io.in <> arb.io.out
   * }}}
   */
+@chiselName
 class Arbiter[T <: Data](gen: T, n: Int) extends Module {
   val io = IO(new ArbiterIO(gen, n))
 

--- a/src/main/scala/chisel3/util/CircuitMath.scala
+++ b/src/main/scala/chisel3/util/CircuitMath.scala
@@ -6,6 +6,7 @@
 package chisel3.util
 
 import chisel3._
+import chisel3.internal.naming.chiselName  // can't use chisel3_ version because of compile order
 
 /** Returns the base-2 integer logarithm of an UInt.
   *
@@ -21,6 +22,7 @@ import chisel3._
 object Log2 {
   /** Returns the base-2 integer logarithm of the least-significant `width` bits of an UInt.
     */
+  @chiselName
   def apply(x: Bits, width: Int): UInt = {
     if (width < 2) {
       0.U

--- a/src/main/scala/chisel3/util/Counter.scala
+++ b/src/main/scala/chisel3/util/Counter.scala
@@ -3,6 +3,7 @@
 package chisel3.util
 
 import chisel3._
+import chisel3.internal.naming.chiselName  // can't use chisel3_ version because of compile order
 //import chisel3.core.ExplicitCompileOptions.Strict
 
 /** A counter module
@@ -10,6 +11,7 @@ import chisel3._
   * @param n number of counts before the counter resets (or one more than the
   * maximum output value of the counter), need not be a power of two
   */
+@chiselName
 class Counter(val n: Int) {
   require(n >= 0)
   val value = if (n > 1) Reg(init=0.U(log2Up(n).W)) else 0.U
@@ -53,6 +55,7 @@ object Counter
     * }
     * }}}
     */
+  @chiselName
   def apply(cond: Bool, n: Int): (UInt, Bool) = {
     val c = new Counter(n)
     var wrap: Bool = null

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -6,6 +6,8 @@
 package chisel3.util
 
 import chisel3._
+import chisel3.internal.naming._  // can't use chisel3_ version because of compile order
+
 // TODO: remove this once we have CompileOptions threaded through the macro system.
 import chisel3.core.ExplicitCompileOptions.NotStrict
 
@@ -85,6 +87,7 @@ object Decoupled
     *
     * @note unsafe (and will error) on the producer (input) side of an IrrevocableIO
     */
+  @chiselName
   def apply[T <: Data](irr: IrrevocableIO[T]): DecoupledIO[T] = {
     require(irr.bits.flatten forall (_.dir == OUTPUT), "Only safe to cast produced Irrevocable bits to Decoupled.")
     val d = Wire(new DecoupledIO(irr.bits))
@@ -164,6 +167,7 @@ class QueueIO[T <: Data](gen: T, entries: Int) extends Bundle
   * consumer.io.in <> q.io.deq
   * }}}
   */
+@chiselName
 class Queue[T <: Data](gen: T,
                        val entries: Int,
                        pipe: Boolean = false,
@@ -240,6 +244,7 @@ extends Module(override_reset=override_reset) {
 object Queue
 {
   /** Create a queue and supply a DecoupledIO containing the product. */
+  @chiselName
   def apply[T <: Data](
       enq: ReadyValidIO[T],
       entries: Int = 2,
@@ -257,6 +262,7 @@ object Queue
     * Irrevocable semantics; we didn't want to change the return type of
     * apply() for backwards compatibility reasons.
     */
+  @chiselName
   def irrevocable[T <: Data](
       enq: ReadyValidIO[T],
       entries: Int = 2,

--- a/src/main/scala/chisel3/util/LFSR.scala
+++ b/src/main/scala/chisel3/util/LFSR.scala
@@ -6,6 +6,7 @@
 package chisel3.util
 
 import chisel3._
+import chisel3.internal.naming.chiselName  // can't use chisel3_ version because of compile order
 //import chisel3.core.ExplicitCompileOptions.Strict
 
 // scalastyle:off magic.number
@@ -15,6 +16,7 @@ object LFSR16 {
     *
     * @param increment optional control to gate when the LFSR updates.
     */
+  @chiselName
   def apply(increment: Bool = true.B): UInt = {
     val width = 16
     val lfsr = Reg(init=1.U(width.W))

--- a/src/main/scala/chisel3/util/Valid.scala
+++ b/src/main/scala/chisel3/util/Valid.scala
@@ -6,6 +6,8 @@
 package chisel3.util
 
 import chisel3._
+import chisel3.internal.naming.chiselName  // can't use chisel3_ version because of compile order
+
 // TODO: remove this once we have CompileOptions threaded through the macro system.
 import chisel3.core.ExplicitCompileOptions.NotStrict
 
@@ -34,6 +36,7 @@ object Valid {
   */
 object Pipe
 {
+  @chiselName
   def apply[T <: Data](enqValid: Bool, enqBits: T, latency: Int): Valid[T] = {
     if (latency == 0) {
       val out = Wire(Valid(enqBits))


### PR DESCRIPTION
Won't work in all cases but is better than nothing.

Annotations aren't added in places where it obviously won't work (like recursive functions without a val definition). More discussion is needed on how to handle those cases (perhaps with variable interpolation?), but that's a later thing, preferably as we get more use cases.

Rocket builds and tests fine. Note that when compiling code with this, you may get warnings with "dependencies are invalidated unconditionally" - I think this means forced recompilation as a result of macros and should only show up once.
