### PR TITLE
Escape % in assertion messages

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Assert.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Assert.scala
@@ -52,10 +52,11 @@ object assert { // scalastyle:ignore object.name
 
   def apply_impl_do(cond: Bool, line: String, message: Option[String], data: Bits*)(implicit sourceInfo: SourceInfo) {
     when (!(cond || Builder.forcedReset)) {
-      message match {
-        case Some(str) => printf.printfWithoutReset(s"Assertion failed: $str\n    at $line\n", data:_*)
-        case None => printf.printfWithoutReset(s"Assertion failed\n    at $line\n", data:_*)
+      val fmt = message match {
+        case Some(str) => s"Assertion failed: $str\n    at $line\n"
+        case None => s"Assertion failed\n    at $line\n"
       }
+      printf.printfWithoutReset(fmt.replaceAll("%", "%%"), data:_*)
       pushCommand(Stop(sourceInfo, Node(Builder.forcedClock), 1))
     }
   }

--- a/src/test/scala/chiselTests/Assert.scala
+++ b/src/test/scala/chiselTests/Assert.scala
@@ -44,6 +44,12 @@ class PipelinedResetTester extends BasicTester {
   }
 }
 
+class ModuloAssertTester extends BasicTester {
+  assert((4.U % 2.U) === 0.U)
+  assert(1.U === 1.U, "I'm 110% sure this will succeed")
+  stop()
+}
+
 class AssertSpec extends ChiselFlatSpec {
   "A failing assertion" should "fail the testbench" in {
     assert(!runTester{ new FailingAssertTester })
@@ -53,5 +59,8 @@ class AssertSpec extends ChiselFlatSpec {
   }
   "An assertion" should "not assert until we come out of reset" in {
     assertTesterPasses{ new PipelinedResetTester }
+  }
+  "Assertions" should "allow the modulo operator % in the message" in {
+    assertTesterPasses{ new ModuloAssertTester }
   }
 }


### PR DESCRIPTION
Note that currently assertions with % in the message or in the line or with % in the filename will all fail to compile