### PR TITLE
Fend off future bug - replace FixedPoint ":=" with "connect".

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -790,8 +790,8 @@ sealed class FixedPoint private (width: Width, val binaryPoint: BinaryPoint, lit
     new FixedPoint(w, binaryPoint).asInstanceOf[this.type]
   private[chisel3] def toType = s"Fixed$width$binaryPoint"
 
-  def := (that: Data)(implicit sourceInfo: SourceInfo): Unit = that match {
-    case _: FixedPoint => this connect that
+  override def connect (that: Data)(implicit sourceInfo: SourceInfo, connectCompileOptions: CompileOptions): Unit = that match {
+    case _: FixedPoint => super.connect(that)
     case _ => this badConnect that
   }
 


### PR DESCRIPTION
This turned up after updating #494 (Remove explicit import of NotStrict) and adding the missing implicit CompileOptions to `:=`'s signature at which point Scala pointed out FixedPoint's `:=` could not override Data's `final :=` with the same signature: the implicit time bomb.