### PR TITLE
Remove check on potentialy empty string for Record names.

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -26,8 +26,8 @@ private[chisel3] class Namespace(keywords: Set[String]) {
     def legalStart(c: Char) = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
     def legal(c: Char) = legalStart(c) || (c >= '0' && c <= '9')
     val res = s filter legal
-    val headOk = if (leadingDigitOk) legal(res.head) else legalStart(res.head)
-    if (res.isEmpty || !headOk) s"_$res" else res
+    val headOk = (!res.isEmpty) && (leadingDigitOk || legalStart(res.head))
+    if (headOk) res else s"_$res"
   }
 
   def contains(elem: String): Boolean = names.contains(elem)


### PR DESCRIPTION
@terpstra -- apparently I don't have the ability to push to Chisel3. 

This does what I'd expect, but seems perhaps FIRRTL can't handle numbers as names either.
Note the difference between how a Vec (the uarts) and a Record (the spis) are output to FIRRTL.

```
    io.uarts[0] <- uart_0.io.port @[UARTPeriphery.scala 36:8]
    io.uarts[1] <- uart_1.io.port @[UARTPeriphery.scala 36:8]
    io.spis.0 <- spi_0.io.port @[SPIPeriphery.scala 32:8]
    io.spis.1 <- spi_1.io.port @[SPIPeriphery.scala 32:8]
...
    uart_pins_0.io.uart <- RocketChipTop.io.uarts[0]
    uart_pins_1.io.uart <- RocketChipTop.io.uarts[1]
    spi_pins_0.io.spi <- RocketChipTop.io.spis.0 
    spi_pins_1.io.spi <- RocketChipTop.io.spis.1 
```

FIRRTL gives these errors on the SPI lines:

```
line 265272:12 no viable alternative at input 'io.spis.0'
line 265273:12 no viable alternative at input 'io.spis.1'
...
line 266421:52 no viable alternative at input '0'
line 266422:52 no viable alternative at input '1'
```

