### PR TITLE
Bugfix #513. Fix BPSet width inference in Chisel3

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -853,8 +853,12 @@ sealed class FixedPoint private (width: Width, val binaryPoint: BinaryPoint, lit
 
   final def setBinaryPoint(that: Int): FixedPoint = macro SourceInfoTransform.thatArg
 
-  def do_setBinaryPoint(that: Int)(implicit sourceInfo: SourceInfo): FixedPoint =
-    binop(sourceInfo, FixedPoint(this.width, KnownBinaryPoint(that)), SetBinaryPoint, that)
+  def do_setBinaryPoint(that: Int)(implicit sourceInfo: SourceInfo): FixedPoint = this.binaryPoint match {
+    case KnownBinaryPoint(value) =>
+      binop(sourceInfo, FixedPoint(this.width + (that - value), KnownBinaryPoint(that)), SetBinaryPoint, that)
+    case _ =>
+      binop(sourceInfo, FixedPoint(UnknownWidth(), KnownBinaryPoint(that)), SetBinaryPoint, that)
+  }
 
   /** Returns this wire bitwise-inverted. */
   def do_unary_~ (implicit sourceInfo: SourceInfo): FixedPoint =

--- a/src/test/scala/chiselTests/FixedPointSpec.scala
+++ b/src/test/scala/chiselTests/FixedPointSpec.scala
@@ -80,16 +80,22 @@ class FixedPointFromBitsTester extends BasicTester {
 
 class SBP extends Module {
   val io = IO(new Bundle {
-    val in =  Input(FixedPoint(6.W, 2.BP))
-    val out = Output(FixedPoint(4.W, 0.BP))
+    val in1 =  Input(FixedPoint(6.W, 2.BP))
+    val in2 =  Input(FixedPoint())
+    val out1 = Output(FixedPoint(4.W, 0.BP))
+    val out2 = Output(FixedPoint(4.W, 0.BP))
   })
-  io.out := io.in.setBinaryPoint(0)
+  io.out1 := io.in1.setBinaryPoint(0)
+  io.out2 := io.in2.setBinaryPoint(0)
 }
+
 class SBPTester extends BasicTester {
   val dut = Module(new SBP)
-  dut.io.in := 3.75.F(2.BP)
+  dut.io.in1 := 3.75.F(2.BP)
+  dut.io.in2 := 3.75.F(2.BP)
 
-  assert(dut.io.out === 3.0.F(0.BP))
+  assert(dut.io.out1 === 3.0.F(0.BP))
+  assert(dut.io.out2 === 3.0.F(0.BP))
 
   stop()
 }

--- a/src/test/scala/chiselTests/FixedPointSpec.scala
+++ b/src/test/scala/chiselTests/FixedPointSpec.scala
@@ -80,22 +80,21 @@ class FixedPointFromBitsTester extends BasicTester {
 
 class SBP extends Module {
   val io = IO(new Bundle {
-    val in1 =  Input(FixedPoint(6.W, 2.BP))
-    val in2 =  Input(FixedPoint())
-    val out1 = Output(FixedPoint(4.W, 0.BP))
-    val out2 = Output(FixedPoint(4.W, 0.BP))
+    val in =  Input(FixedPoint(6.W, 2.BP))
+    val out = Output(FixedPoint(4.W, 0.BP))
   })
-  io.out1 := io.in1.setBinaryPoint(0)
-  io.out2 := io.in2.setBinaryPoint(0)
+  io.out := io.in.setBinaryPoint(0)
 }
 
 class SBPTester extends BasicTester {
   val dut = Module(new SBP)
-  dut.io.in1 := 3.75.F(2.BP)
-  dut.io.in2 := 3.75.F(2.BP)
+  dut.io.in := 3.75.F(2.BP)
 
-  assert(dut.io.out1 === 3.0.F(0.BP))
-  assert(dut.io.out2 === 3.0.F(0.BP))
+  assert(dut.io.out === 3.0.F(0.BP))
+
+  val test = Wire(FixedPoint(10.W, 5.BP))
+  val q = test.setBinaryPoint(18)
+  assert(q.getWidth.U === 23.U)
 
   stop()
 }


### PR DESCRIPTION
Ready to review and merge.