### PR TITLE
Remove log2Up and log2Down from API

### DIFF
--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -215,12 +215,24 @@ package object Chisel {     // scalastyle:ignore package.object.name
     val TesterDriver = chisel3.testers.TesterDriver
   }
 
-
-  val log2Up = chisel3.util.log2Up
   val log2Ceil = chisel3.util.log2Ceil
-  val log2Down = chisel3.util.log2Down
   val log2Floor = chisel3.util.log2Floor
   val isPow2 = chisel3.util.isPow2
+
+  /** Compute the log2 rounded up with min value of 1 */
+  object log2Up {
+    def apply(in: BigInt): Int = {
+      require(in >= 0)
+      1 max (in-1).bitLength
+    }
+    def apply(in: Int): Int = apply(BigInt(in))
+  }
+
+  /** Compute the log2 rounded down with min value of 1 */
+  object log2Down {
+    def apply(in: BigInt): Int = log2Up(in) - (if (isPow2(in)) 0 else 1)
+    def apply(in: Int): Int = apply(BigInt(in))
+  }
 
   val BitPat = chisel3.util.BitPat
   type BitPat = chisel3.util.BitPat

--- a/src/main/scala/chisel3/util/Arbiter.scala
+++ b/src/main/scala/chisel3/util/Arbiter.scala
@@ -19,7 +19,7 @@ import chisel3.core.ExplicitCompileOptions.NotStrict
 class ArbiterIO[T <: Data](gen: T, n: Int) extends Bundle {
   val in  = Flipped(Vec(n, Decoupled(gen)))
   val out = Decoupled(gen)
-  val chosen = Output(UInt(log2Up(n).W))
+  val chosen = Output(UInt(log2Ceil(n).W))
 }
 
 /** Arbiter Control determining which producer has access

--- a/src/main/scala/chisel3/util/Bitwise.scala
+++ b/src/main/scala/chisel3/util/Bitwise.scala
@@ -90,10 +90,10 @@ object Fill {
   * }}}
   */
 object Reverse {
-  private def doit(in: UInt, length: Int): UInt = {
-    if (length == 1) {
-      in
-    } else if (isPow2(length) && length >= 8 && length <= 64) {
+  private def doit(in: UInt, length: Int): UInt = length match {
+    case _ if length < 0 => throw new IllegalArgumentException(s"length (=$length) must be nonnegative integer.")
+    case _ if length <= 1 => in
+    case _ if isPow2(length) && length >= 8 && length <= 64 =>
       // This esoterica improves simulation performance
       var res = in
       var shift = length >> 1
@@ -104,10 +104,9 @@ object Reverse {
         shift = shift >> 1
       } while (shift > 0)
       res
-    } else {
-      val half = (1 << log2Up(length))/2
+    case _ =>
+      val half = (1 << log2Ceil(length))/2
       Cat(doit(in(half-1,0), half), doit(in(length-1,half), length-half))
-    }
   }
 
   def apply(in: UInt): UInt = doit(in, in.getWidth)

--- a/src/main/scala/chisel3/util/Bitwise.scala
+++ b/src/main/scala/chisel3/util/Bitwise.scala
@@ -65,17 +65,18 @@ object Fill {
     */
   def apply(n: Int, x: UInt): UInt = {
     n match {
+      case _ if n < 0 => throw new IllegalArgumentException(s"n (=$n) must be nonnegative integer.")
       case 0 => UInt(0.W)
       case 1 => x
       case _ if x.isWidthKnown && x.getWidth == 1 =>
         Mux(x.toBool, ((BigInt(1) << n) - 1).asUInt(n.W), 0.U(n.W))
-      case _ if n > 1 =>
-        val p2 = Array.ofDim[UInt](log2Up(n + 1))
+      case _ =>
+        val nBits = log2Ceil(n + 1)
+        val p2 = Array.ofDim[UInt](nBits)
         p2(0) = x
         for (i <- 1 until p2.length)
           p2(i) = Cat(p2(i-1), p2(i-1))
-        Cat((0 until log2Up(n + 1)).filter(i => (n & (1 << i)) != 0).map(p2(_)))
-      case _ => throw new IllegalArgumentException(s"n (=$n) must be nonnegative integer.")
+        Cat((0 until nBits).filter(i => (n & (1 << i)) != 0).map(p2(_)))
     }
   }
 }

--- a/src/main/scala/chisel3/util/Counter.scala
+++ b/src/main/scala/chisel3/util/Counter.scala
@@ -14,7 +14,7 @@ import chisel3.internal.naming.chiselName  // can't use chisel3_ version because
 @chiselName
 class Counter(val n: Int) {
   require(n >= 0)
-  val value = if (n > 1) Reg(init=0.U(log2Up(n).W)) else 0.U
+  val value = if (n > 1) Reg(init=0.U(log2Ceil(n).W)) else 0.U
 
   /** Increment the counter, returning whether the counter currently is at the
     * maximum and will wrap. The incremented value is registered and will be

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -148,7 +148,7 @@ class QueueIO[T <: Data](gen: T, entries: Int) extends Bundle
   /** I/O to enqueue data, is [[Chisel.DecoupledIO]]*/
   val deq = EnqIO(gen)
   /** The current amount of data in the queue */
-  val count = Output(UInt(log2Up(entries + 1).W))
+  val count = Output(UInt(log2Ceil(entries + 1).W))
 
   override def cloneType = new QueueIO(gen, entries).asInstanceOf[this.type]
 }

--- a/src/main/scala/chisel3/util/Enum.scala
+++ b/src/main/scala/chisel3/util/Enum.scala
@@ -10,7 +10,7 @@ import chisel3._
 trait Enum {
   /** Returns a sequence of Bits subtypes with values from 0 until n. Helper method. */
   protected def createValues(n: Int): Seq[UInt] =
-    (0 until n).map(_.U(log2Up(n).W))
+    (0 until n).map(_.U(log2Ceil(n).W))
 
   /** Returns n unique UInt values, use with unpacking to specify an enumeration.
     *

--- a/src/main/scala/chisel3/util/Math.scala
+++ b/src/main/scala/chisel3/util/Math.scala
@@ -8,12 +8,9 @@ package chisel3.util
 import chisel3._
 
 /** Compute the log2 rounded up with min value of 1 */
+@deprecated("Use log2Ceil instead", "chisel3")
 object log2Up {
-  def apply(in: BigInt): Int = {
-    require(in >= 0)
-    1 max (in-1).bitLength
-  }
-  def apply(in: Int): Int = apply(BigInt(in))
+  def apply(in: BigInt): Int = Chisel.log2Up(in)
 }
 
 /** Compute the log2 rounded up */
@@ -26,9 +23,9 @@ object log2Ceil {
 }
 
 /** Compute the log2 rounded down with min value of 1 */
+@deprecated("Use log2Floor instead", "chisel3")
 object log2Down {
-  def apply(in: BigInt): Int = log2Up(in) - (if (isPow2(in)) 0 else 1)
-  def apply(in: Int): Int = apply(BigInt(in))
+  def apply(in: BigInt): Int = Chisel.log2Down(in)
 }
 
 /** Compute the log2 rounded down */

--- a/src/main/scala/chisel3/util/OneHot.scala
+++ b/src/main/scala/chisel3/util/OneHot.scala
@@ -42,12 +42,13 @@ object PriorityEncoder {
 /** Returns the one hot encoding of the input UInt.
   */
 object UIntToOH {
-  def apply(in: UInt, width: Int = -1): UInt =
-    if (width == -1) {
-      1.U << in
-    } else {
-      (1.U << in(log2Up(width)-1,0))(width-1,0)
-    }
+  def apply(in: UInt): UInt = 1.U << in
+  def apply(in: UInt, width: Int): UInt = width match {
+    case 0 => 0.U(0.W)
+    case _ =>
+      val shiftAmount = in((log2Ceil(width) - 1) max 0, 0)
+      (1.U << shiftAmount)(width - 1, 0)
+  }
 }
 
 /** Returns a bit vector in which only the least-significant 1 bit in the input vector, if any,

--- a/src/main/scala/chisel3/util/OneHot.scala
+++ b/src/main/scala/chisel3/util/OneHot.scala
@@ -22,7 +22,7 @@ object OHToUInt {
     if (width <= 2) {
       Log2(in, width)
     } else {
-      val mid = 1 << (log2Up(width)-1)
+      val mid = 1 << (log2Ceil(width)-1)
       val hi = in(width-1, mid)
       val lo = in(mid-1, 0)
       Cat(hi.orR, apply(hi | lo, mid))

--- a/src/test/scala/chiselTests/BlackBox.scala
+++ b/src/test/scala/chiselTests/BlackBox.scala
@@ -86,10 +86,10 @@ class BlackBoxWithClockTester extends BasicTester {
 }
 
 class BlackBoxConstant(value: Int) extends BlackBox(
-    Map("VALUE" -> value, "WIDTH" -> log2Up(value + 1))) {
+    Map("VALUE" -> value, "WIDTH" -> log2Ceil(value + 1))) {
   require(value >= 0, "value must be a UInt!")
   val io = IO(new Bundle {
-    val out = UInt(log2Up(value + 1).W).asOutput
+    val out = UInt(log2Ceil(value + 1).W).asOutput
   })
 }
 

--- a/src/test/scala/chiselTests/Stack.scala
+++ b/src/test/scala/chiselTests/Stack.scala
@@ -17,7 +17,7 @@ class ChiselStack(val depth: Int) extends Module {
   })
 
   val stack_mem = Mem(depth, UInt(32.W))
-  val sp        = Reg(init = 0.U(log2Up(depth+1).W))
+  val sp        = Reg(init = 0.U(log2Ceil(depth+1).W))
   val out       = Reg(init = 0.U(32.W))
 
   when (io.en) {

--- a/src/test/scala/chiselTests/Tbl.scala
+++ b/src/test/scala/chiselTests/Tbl.scala
@@ -11,8 +11,8 @@ import chisel3.util._
 
 class Tbl(w: Int, n: Int) extends Module {
   val io = IO(new Bundle {
-    val wi  = Input(UInt(log2Up(n).W))
-    val ri  = Input(UInt(log2Up(n).W))
+    val wi  = Input(UInt(log2Ceil(n).W))
+    val ri  = Input(UInt(log2Ceil(n).W))
     val we  = Input(Bool())
     val  d  = Input(UInt(w.W))
     val  o  = Output(UInt(w.W))

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -97,7 +97,7 @@ class TabulateTester(n: Int) extends BasicTester {
 
 class ShiftRegisterTester(n: Int) extends BasicTester {
   val (cnt, wrap) = Counter(true.B, n*2)
-  val shifter = Reg(Vec(n, UInt(log2Up(n).W)))
+  val shifter = Reg(Vec(n, UInt((log2Ceil(n) max 1).W)))
   (shifter, shifter drop 1).zipped.foreach(_ := _)
   shifter(n-1) := cnt
   when (cnt >= n.asUInt) {

--- a/src/test/scala/examples/VendingMachineGenerator.scala
+++ b/src/test/scala/examples/VendingMachineGenerator.scala
@@ -52,7 +52,7 @@ class VendingMachineGenerator(
   val maxCoin = io.coins.last.value
   val maxValue = (sodaCost + maxCoin - minCoin) / minCoin // normalize to minimum value
 
-  val width = log2Up(maxValue + 1).W
+  val width = log2Ceil(maxValue + 1).W
   val value = Reg(init = 0.asUInt(width))
   val incValue = Wire(init = 0.asUInt(width))
   val doDispense = value >= (sodaCost / minCoin).U


### PR DESCRIPTION
These methods are a scourge.  They are mathematically incorrect (log2(1) should yield 0, not 1), and so their use results in corner-case bugs that never fail to surprise good programmers.  For an example that occurred just this evening, see: https://github.com/ucb-bar/rocket-chip/pull/563

For historical context, log2Up was created within rocket-chip to work around zero-width wire limitations in chisel1.  A chisel maintainer imported them into chisel, apparently without much regard for the fact that they were deliberately defined incorrectly.  So, while we must keep them in the compatibility layer, we should take this compatibility-breaking opportunity to purge them.

This PR moves these methods to the compatibility layer and purges all of their use in the chisel codebase itself.  In most cases within Chisel itself, the arguments to log2Up are easily shown to be at least 2, so replacing them was easy.

However, I noticed something concerning in the process: when I replaced log2Up in ShiftRegisterTester, I got a Verilator compile error.  I suspect this is a FIRRTL bug that @azidar's recent work will fix, and it's totally unrelated to this PR, so I worked around it in the mean time (by using (log2Ceil(x) max 1) instead of log2Ceil(x)).