### PR TITLE
Revert "Change Vec creation to check if gen is lit (and hence needs t…

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -42,7 +42,7 @@ object Vec {
     *
     * @note elements are NOT assigned by default and have no value
     */
-  def apply[T <: Data](n: Int, gen: T): Vec[T] = new Vec(gen.chiselCloneType, n)
+  def apply[T <: Data](n: Int, gen: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] = new Vec(gen.chiselCloneType, n)
 
   @deprecated("Vec argument order should be size, t; this will be removed by the official release", "chisel3")
   def apply[T <: Data](gen: T, n: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] = new Vec(gen.chiselCloneType, n)

--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -42,19 +42,10 @@ object Vec {
     *
     * @note elements are NOT assigned by default and have no value
     */
-  def apply[T <: Data](n: Int, gen: T): Vec[T] = macro VecTransform.apply_ngen;
-
-  def do_apply[T <: Data](n: Int, gen: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] = {
-    if ( gen.isLit ) {
-      Vec(Seq.fill(n)(gen))
-    } else {
-      new Vec(gen.chiselCloneType, n)
-    }
-  }
+  def apply[T <: Data](n: Int, gen: T): Vec[T] = new Vec(gen.chiselCloneType, n)
 
   @deprecated("Vec argument order should be size, t; this will be removed by the official release", "chisel3")
-  def apply[T <: Data](gen: T, n: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
-    do_apply(n, gen)
+  def apply[T <: Data](gen: T, n: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] = new Vec(gen.chiselCloneType, n)
 
   /** Creates a new [[Vec]] composed of elements of the input Seq of [[Data]]
     * nodes.

--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -323,14 +323,14 @@ trait VecLike[T <: Data] extends collection.IndexedSeq[T] with HasId {
 
   /** Outputs the index of the first element for which p outputs true.
     */
-  def indexWhere(p: T => Bool): UInt = macro SourceInfoTransform.pArg
+  def indexWhere(p: T => Bool): UInt = macro CompileOptionsTransform.pArg
 
   def do_indexWhere(p: T => Bool)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
     SeqUtils.priorityMux(indexWhereHelper(p))
 
   /** Outputs the index of the last element for which p outputs true.
     */
-  def lastIndexWhere(p: T => Bool): UInt = macro SourceInfoTransform.pArg
+  def lastIndexWhere(p: T => Bool): UInt = macro CompileOptionsTransform.pArg
 
   def do_lastIndexWhere(p: T => Bool)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
     SeqUtils.priorityMux(indexWhereHelper(p).reverse)

--- a/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/coreMacros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -75,9 +75,6 @@ class MuxTransform(val c: Context) extends SourceInfoTransformMacro {
 
 class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
-  def apply_ngen(n: c.Tree, gen: c.Tree): c.Tree = {
-    q"$thisObj.do_apply($n,$gen)($implicitSourceInfo, $implicitCompileOptions)"
-  }
   def apply_elts(elts: c.Tree): c.Tree = {
     q"$thisObj.do_apply($elts)($implicitSourceInfo, $implicitCompileOptions)"
   }

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -12,7 +12,7 @@ class LitTesterMod(vecSize: Int) extends Module {
   val io = IO(new Bundle {
     val out = Output(Vec(vecSize, UInt()))
   })
-  io.out := Vec(vecSize, 0.U)
+  io.out := Vec(Seq.fill(vecSize){0.U})
 }
 
 class RegTesterMod(vecSize: Int) extends Module {
@@ -20,7 +20,7 @@ class RegTesterMod(vecSize: Int) extends Module {
     val in = Input(Vec(vecSize, UInt()))
     val out = Output(Vec(vecSize, UInt()))
   })
-  val vecReg = Reg(init = Vec(vecSize, 0.U), next = io.in)
+  val vecReg = Reg(init = Vec(Seq.fill(vecSize){0.U}), next = io.in)
   io.out := vecReg
 }
 
@@ -30,6 +30,15 @@ class IOTesterMod(vecSize: Int) extends Module {
     val out = Output(Vec(vecSize, UInt()))
   })
   io.out := io.in
+}
+
+class OneBitUnitRegVec extends Module {
+  val io = IO(new Bundle {
+    val out = Output(UInt(1.W))
+  })
+  val oneBitUnitRegVec = Reg(Vec(1, 1.U))
+  oneBitUnitRegVec(0) := 1.U(1.W)
+  io.out := oneBitUnitRegVec(0)
 }
 
 class LitTester(w: Int, values: List[Int]) extends BasicTester {
@@ -119,6 +128,12 @@ class HugeVecTester(n: Int) extends BasicTester {
   stop()
 }
 
+class OneBitUnitRegVecTester extends BasicTester {
+  val dut = Module(new OneBitUnitRegVec)
+  assert(dut.io.out === 1.U)
+  stop()
+}
+
 class VecSpec extends ChiselPropSpec {
   // Disable shrinking on error.
   implicit val noShrinkListVal = Shrink[List[Int]](_ => Stream.empty)
@@ -167,5 +182,9 @@ class VecSpec extends ChiselPropSpec {
 
   property("Infering widths on huge Vecs should not cause a stack overflow") {
     assertTesterPasses { new HugeVecTester(10000) }
+  }
+
+  property("A Reg of a Vec of a single 1 bit element should compile and work") {
+    assertTesterPasses{ new OneBitUnitRegVecTester }
   }
 }


### PR DESCRIPTION
…o be declared)"

This reverts commit dc86e7e1734d6abacb739b488df1de231e6b41b2.
This may address #522 - using chiselCloneType (instead of cloneType) to preserve directionality.