### PR TITLE
For transforms that require order, allow setting order via firrtl execution options

### DIFF
--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -151,11 +151,15 @@ object Driver extends BackendCompilationUtilities {
     val transforms = circuit.annotations.map(_.transform).toSet.map { transformClass: Class[_ <: Transform] =>
       transformClass.newInstance()
     }
+
+    val orderedTransforms = (optionsManager.firrtlOptions.customTransforms ++ transforms.toList).map(
+      x => x.getClass).distinct.map(x => x.newInstance())
+
     /* This passes the firrtl source and annotations directly to firrtl */
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(
       firrtlSource = Some(firrtlString),
       annotations = optionsManager.firrtlOptions.annotations ++ circuit.annotations.toList,
-      customTransforms = optionsManager.firrtlOptions.customTransforms ++ transforms.toList)
+      customTransforms = orderedTransforms)
 
     val firrtlExecutionResult = if(chiselOptions.runFirrtlCompiler) {
       Some(firrtl.Driver.execute(optionsManager))


### PR DESCRIPTION
So it looks like transforms are added to the transform list via circuit annotations here. The problem is, the original method didn't allow you flexibility as to how the transforms were ordered (beside being high, middle, low form). I changed the code so that you can specify a list of ordered transforms (via firrtlOptions.customTransforms). If I do a distinct, since customTransforms occurs before the annotation-derived transforms, the order specified by customTransforms should be used. 

I'm not 100% sure this works, b/c for whatever reason, BlackBoxSourceHelpers seems to still be run twice... (Maybe it's injected into the transform list elsewhere???)

This is getting to be somewhat urgent.

```
Finished ***LowFirrtlOptimization***
***LowFirrtlOptimization*** took 2.9 ms

Starting ***BlackBoxSourceHelper***
Finished ***BlackBoxSourceHelper***
***BlackBoxSourceHelper*** took 0.4 ms

Starting ***AddIOPadsTransform***
Starting Legalize
Finished Legalize
Legalize took 0.2 ms

Starting Resolve Genders
Finished Resolve Genders
Resolve Genders took 0.2 ms

Starting Infer Types
Finished Infer Types
Infer Types took 1.0 ms

Starting Add Padframe
Finished Add Padframe
Add Padframe took 1.1 ms

Starting Remove Empty Statements
Finished Remove Empty Statements
Remove Empty Statements took 0.1 ms

Starting Check Initialization
Finished Check Initialization
Check Initialization took 0.4 ms

Starting Infer Types
Finished Infer Types
Infer Types took 1.9 ms

Starting Uniquify Identifiers
Finished Uniquify Identifiers
Uniquify Identifiers took 2.5 ms

Starting Resolve Kinds
Finished Resolve Kinds
Resolve Kinds took 0.9 ms

Starting Resolve Genders
Finished Resolve Genders
Resolve Genders took 0.6 ms

Finished ***AddIOPadsTransform***
***AddIOPadsTransform*** took 60.5 ms

Starting ***BlackBoxSourceHelper***
Finished ***BlackBoxSourceHelper***
***BlackBoxSourceHelper*** took 1.3 ms

Starting Add temporary nodes with verilog widths for modulus
Finished Add temporary nodes with verilog widths for modulus
Add temporary nodes with verilog widths for modulus took 0.3 ms

Starting Verilog Wrap
Finished Verilog Wrap
Verilog Wrap took 0.5 ms

Starting Verilog Rename
Finished Verilog Rename
Verilog Rename took 1.0 ms

Starting Verilog Prep
Finished Verilog Prep
Verilog Prep took 1.9 ms
```