### PR TITLE
Fixed oneHotMux can't handle only one input

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/SeqUtils.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/SeqUtils.scala
@@ -55,7 +55,9 @@ private[chisel3] object SeqUtils {
 
   def do_oneHotMux[T <: Data](in: Iterable[(Bool, T)])(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     if (in.tail.isEmpty) {
-      in.head._2
+      val result = Mux(in.head._1, in.head._2.asUInt, UInt(0))
+      val width = in.head._2.width
+      in.head._2.cloneTypeWidth(width).fromBits(result)
     } else {
       val masked = for ((s, i) <- in) yield Mux(s, i.asUInt, 0.U)
       val output = cloneSupertype(in.toSeq map {_._2}, "oneHotMux")


### PR DESCRIPTION
When there is only one select signal, the original one-hot Mux ignores the select signal and always return the input data.

I think the one-hot Mux in that case should return input data when select signal is set or return zero when select signal is clear.