### PR TITLE
Fixed fix, allow Mux of different binary points and widths

### DIFF
--- a/src/test/scala/chiselTests/FixedPointSpec.scala
+++ b/src/test/scala/chiselTests/FixedPointSpec.scala
@@ -82,9 +82,12 @@ class FixedPointMuxTester extends BasicTester {
   val largeWidthLowPrecision = 6.0.F(3.W, 0.BP)
   val smallWidthHighPrecision = 0.25.F(2.W, 2.BP)
   val unknownWidthLowPrecision = 6.0.F(0.BP)
+  val unknownFixed = Wire(FixedPoint())
+  unknownFixed := smallWidthHighPrecision
   
   assert(Mux(true.B, largeWidthLowPrecision, smallWidthHighPrecision) === 6.0.F(0.BP))
   assert(Mux(false.B, largeWidthLowPrecision, smallWidthHighPrecision) === 0.25.F(2.BP))
+  assert(Mux(false.B, largeWidthLowPrecision, unknownFixed) === 0.25.F(2.BP))
   assert(Mux(true.B, unknownWidthLowPrecision, smallWidthHighPrecision) === 6.0.F(0.BP))
   
   stop()

--- a/src/test/scala/chiselTests/FixedPointSpec.scala
+++ b/src/test/scala/chiselTests/FixedPointSpec.scala
@@ -78,6 +78,18 @@ class FixedPointFromBitsTester extends BasicTester {
   stop()
 }
 
+class FixedPointMuxTester extends BasicTester {
+  val largeWidthLowPrecision = 6.0.F(3.W, 0.BP)
+  val smallWidthHighPrecision = 0.25.F(2.W, 2.BP)
+  val unknownWidthLowPrecision = 6.0.F(0.BP)
+  
+  assert(Mux(true.B, largeWidthLowPrecision, smallWidthHighPrecision) === 6.0.F(0.BP))
+  assert(Mux(false.B, largeWidthLowPrecision, smallWidthHighPrecision) === 0.25.F(2.BP))
+  assert(Mux(true.B, unknownWidthLowPrecision, smallWidthHighPrecision) === 6.0.F(0.BP))
+  
+  stop()
+}
+
 class SBP extends Module {
   val io = IO(new Bundle {
     val in =  Input(FixedPoint(6.W, 2.BP))
@@ -105,5 +117,8 @@ class FixedPointSpec extends ChiselPropSpec {
   }
   property("should allow fromBits") {
     assertTesterPasses { new FixedPointFromBitsTester }
+  }
+  property("should mux different widths and binary points") {
+    assertTesterPasses { new FixedPointMuxTester }
   }
 }


### PR DESCRIPTION
Resolves #557 

The implementation is ugly, but I can't think of a better way and this is a feature that makes sense. The larger problem seems to be that Chisel is duplicating width inferencing work with FIRRTL, but without all the information. The larger discussion might be whether that is a good practice, as removing width propagation in Chisel can remove a lot of complexity and special cases.
