### PR TITLE
Fix getWidth on empty Vecs; add test

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -19,7 +19,7 @@ sealed abstract class Aggregate extends Data {
     */
   def getElements: Seq[Data]
 
-  private[core] def width: Width = getElements.map(_.width).reduce(_ + _)
+  private[core] def width: Width = getElements.map(_.width).foldLeft(0.W)(_ + _)
   private[core] def legacyConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit =
     pushCommand(BulkConnect(sourceInfo, this.lref, that.lref))
 

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -134,6 +134,11 @@ class OneBitUnitRegVecTester extends BasicTester {
   stop()
 }
 
+class ZeroEntryVecTester extends BasicTester {
+  require(Vec(0, Bool()).getWidth == 0)
+  stop()
+}
+
 class VecSpec extends ChiselPropSpec {
   // Disable shrinking on error.
   implicit val noShrinkListVal = Shrink[List[Int]](_ => Stream.empty)
@@ -186,5 +191,9 @@ class VecSpec extends ChiselPropSpec {
 
   property("A Reg of a Vec of a single 1 bit element should compile and work") {
     assertTesterPasses{ new OneBitUnitRegVecTester }
+  }
+
+  property("A Vec with zero entries should compile and have zero width") {
+    assertTesterPasses{ new ZeroEntryVecTester }
   }
 }


### PR DESCRIPTION
Use fold(0) instead of reduce to handle the corner case.