### PR TITLE
Support Vec(0) fields in Bundles, just like Option[Data]; add test

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -499,6 +499,7 @@ class Bundle extends Record {
     * be one, otherwise returns None.
     */
   private def getBundleField(m: java.lang.reflect.Method): Option[Data] = m.invoke(this) match {
+    case v: Vec[_] if v.isEmpty => None
     case d: Data => Some(d)
     case Some(d: Data) => Some(d)
     case _ => None

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -136,6 +136,14 @@ class OneBitUnitRegVecTester extends BasicTester {
 
 class ZeroEntryVecTester extends BasicTester {
   require(Vec(0, Bool()).getWidth == 0)
+
+  val bundleWithZeroEntryVec = new Bundle {
+    val foo = Bool()
+    val bar = Vec(0, Bool())
+  }
+  require(0.U.asTypeOf(bundleWithZeroEntryVec).getWidth == 1)
+  require(bundleWithZeroEntryVec.asUInt.getWidth == 1)
+
   stop()
 }
 


### PR DESCRIPTION
This also allows asUInt/asTypeOf to work properly on those Bundles,
even though zero-width wire support is lacking.