### PR TITLE
Creating FixedPoint literals was throwing away width

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -947,7 +947,7 @@ object FixedPoint {
     * Use PrivateObject to force users to specify width and binaryPoint by name
     */
   def fromBigInt(value: BigInt, width: Width, binaryPoint: BinaryPoint): FixedPoint = {
-    apply(value, Width(), binaryPoint)
+    apply(value, width, binaryPoint)
   }
   /** Create an FixedPoint literal with inferred width from BigInt.
     * Use PrivateObject to force users to specify width and binaryPoint by name

--- a/src/test/scala/chiselTests/FixedPointSpec.scala
+++ b/src/test/scala/chiselTests/FixedPointSpec.scala
@@ -79,7 +79,7 @@ class FixedPointFromBitsTester extends BasicTester {
 }
 
 class FixedPointMuxTester extends BasicTester {
-  val largeWidthLowPrecision = 6.0.F(3.W, 0.BP)
+  val largeWidthLowPrecision = 6.0.F(4.W, 0.BP)
   val smallWidthHighPrecision = 0.25.F(2.W, 2.BP)
   val unknownWidthLowPrecision = 6.0.F(0.BP)
   val unknownFixed = Wire(FixedPoint())


### PR DESCRIPTION
Creating FixedPoint literals was throwing away width even when specifically provided.
This caused one hot muxing problems in dsptools
FixedPoint spec fixed based on error uncovered by this change