### PR TITLE
Use input element to decide if Vec of values has direction

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -73,7 +73,9 @@ object Vec {
 
     def doConnect(sink: T, source: T) = {
       // TODO: this looks bad, and should feel bad. Replace with a better abstraction.
-      val hasDirectioned = vec.sample_element match {
+      // NOTE: Must use elts.head instead of vec.sample_element because vec.sample_element has
+      //       WireBinding which does not have a direction
+      val hasDirectioned = elts.head match {
         case t: Aggregate => t.flatten.exists(_.dir != Direction.Unspecified)
         case t: Element => t.dir != Direction.Unspecified
       }


### PR DESCRIPTION
Using the sample_element of the created wire is incorrect because Wires have no
direction so the Wire constructed for a Vec of Module IO was constructed
incorrectly. Fixes #569 and resolves #522.

Once I figured out that this was the problem, I was confused how you could index into a wire that was of type Vec of Module io and still correctly bulk connect to the directioned inputs. It turns out that this works by using the direction of the other side of the bulk connect as a hint. This has the following two nasty consequences that should be fixed in the Binding refactor:
1. You cannot bulk connect the Bundle ports of two modules that are elements of Vecs.
1. If you try to bulk connect some Bundle port of a module (not in a Vec) to the Bundle port of another module (**is** in a Vec), and the Bundles have the same field names but mismatched directions, this will lead to an silently incorrect successful connection. It doesn't even error in Firrtl.

(1) errors with a reasonable error message in Chisel, it just says it cant figure out the directions.
(2) is the scary one, I'll file a separate issue