### PR TITLE
Define CompileOptions case class to support CompileOptions manipulation.

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/CompileOptions.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/CompileOptions.scala
@@ -37,28 +37,48 @@ object CompileOptions {
 }
 
 object ExplicitCompileOptions {
+  case class CompileOptionsClass (
+                             // Should Record connections require a strict match of fields.
+                             // If true and the same fields aren't present in both source and sink, a MissingFieldException,
+                             // MissingLeftFieldException, or MissingRightFieldException will be thrown.
+                             val connectFieldsMustMatch: Boolean,
+                             // When creating an object that takes a type argument, the argument must be unbound (a pure type).
+                             val declaredTypeMustBeUnbound: Boolean,
+                             // Module IOs should be wrapped in an IO() to define their bindings before the reset of the module is defined.
+                             val requireIOWrap: Boolean,
+                             // If a connection operator fails, don't try the connection with the operands (source and sink) reversed.
+                             val dontTryConnectionsSwapped: Boolean,
+                             // If connection directionality is not explicit, do not use heuristics to attempt to determine it.
+                             val dontAssumeDirectionality: Boolean,
+                             // Issue a deprecation warning if Data.{flip, asInput,asOutput} is used
+                             // instead of Flipped, Input, or Output.
+                             val deprecateOldDirectionMethods: Boolean,
+                             // Check that referenced Data have actually been declared.
+                             val checkSynthesizable: Boolean
+                           ) extends CompileOptions
+
   // Collection of "not strict" connection compile options.
   // These provide compatibility with existing code.
   // import chisel3.core.ExplicitCompileOptions.NotStrict
-  implicit object NotStrict extends CompileOptions {
-    val connectFieldsMustMatch = false
-    val declaredTypeMustBeUnbound = false
-    val requireIOWrap = false
-    val dontTryConnectionsSwapped = false
-    val dontAssumeDirectionality = false
-    val deprecateOldDirectionMethods = false
-    val checkSynthesizable = false
-  }
+  implicit val NotStrict = new CompileOptionsClass (
+    connectFieldsMustMatch = false,
+    declaredTypeMustBeUnbound = false,
+    requireIOWrap = false,
+    dontTryConnectionsSwapped = false,
+    dontAssumeDirectionality = false,
+    deprecateOldDirectionMethods = false,
+    checkSynthesizable = false
+  )
 
   // Collection of "strict" connection compile options, preferred for new code.
   // import chisel3.core.ExplicitCompileOptions.Strict
-  implicit object Strict extends CompileOptions {
-    val connectFieldsMustMatch = true
-    val declaredTypeMustBeUnbound = true
-    val requireIOWrap = true
-    val dontTryConnectionsSwapped = true
-    val dontAssumeDirectionality = true
-    val deprecateOldDirectionMethods = true
-    val checkSynthesizable = true
-  }
+  implicit val Strict = new CompileOptionsClass (
+    connectFieldsMustMatch = true,
+    declaredTypeMustBeUnbound = true,
+    requireIOWrap = true,
+    dontTryConnectionsSwapped = true,
+    dontAssumeDirectionality = true,
+    deprecateOldDirectionMethods = true,
+    checkSynthesizable = true
+  )
 }

--- a/src/test/scala/chiselTests/CompileOptionsTest.scala
+++ b/src/test/scala/chiselTests/CompileOptionsTest.scala
@@ -16,15 +16,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
 
   // Generate a set of options that do not have requireIOWrap enabled, in order to
   // ensure its definition comes from the implicit options passed to the Module constructor.
-  object StrictWithoutIOWrap extends CompileOptions {
-    val connectFieldsMustMatch = true
-    val declaredTypeMustBeUnbound = true
-    val requireIOWrap = false
-    val dontTryConnectionsSwapped = true
-    val dontAssumeDirectionality = true
-    val deprecateOldDirectionMethods = true
-    val checkSynthesizable = true
-  }
+  val strictWithoutIOWrapVal = chisel3.core.ExplicitCompileOptions.Strict.copy(requireIOWrap = false)
 
   class SmallBundle extends Bundle {
     val f1 = UInt(4.W)
@@ -214,7 +206,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
   }
 
   "A Module with wrapped IO when compiled with explicit Strict.CompileOption " should "not throw an exception" in {
-    implicit val strictWithoutIOWrap = StrictWithoutIOWrap
+    implicit val strictWithoutIOWrap = strictWithoutIOWrapVal
     class RequireIOWrapModule extends StrictModule {
       val io = IO(new Bundle {
         val in = UInt(32.W).asInput
@@ -228,7 +220,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
   }
 
   "A Module with unwrapped IO when compiled with explicit NotStrict.CompileOption " should "not throw an exception" in {
-    implicit val strictWithoutIOWrap = StrictWithoutIOWrap
+    implicit val strictWithoutIOWrap = strictWithoutIOWrapVal
     class RequireIOWrapModule extends NotStrictModule {
       val io = new Bundle {
         val in = UInt(32.W).asInput
@@ -243,7 +235,7 @@ class CompileOptionsSpec extends ChiselFlatSpec {
 
   "A Module with unwrapped IO when compiled with explicit Strict.CompileOption " should "throw an exception" in {
     a [BindingException] should be thrownBy {
-      implicit val strictWithoutIOWrap = StrictWithoutIOWrap
+      implicit val strictWithoutIOWrap = strictWithoutIOWrapVal
       class RequireIOWrapModule extends StrictModule {
         val io = new Bundle {
           val in = UInt(32.W).asInput
@@ -259,20 +251,9 @@ class CompileOptionsSpec extends ChiselFlatSpec {
 
   "A Module with unwrapped IO when compiled with an explicit requireIOWrap false " should "not throw an exception" in {
 
-    object StrictNotIOWrap {
+    val strictNotIOWrap = chisel3.core.ExplicitCompileOptions.Strict.copy(requireIOWrap = false, deprecateOldDirectionMethods = false)
 
-      implicit object CompileOptions extends CompileOptions {
-        val connectFieldsMustMatch = true
-        val declaredTypeMustBeUnbound = true
-        val requireIOWrap = false
-        val dontTryConnectionsSwapped = true
-        val dontAssumeDirectionality = true
-        val deprecateOldDirectionMethods = false
-        val checkSynthesizable = true
-      }
-
-    }
-    class NotIOWrapModule extends Module()(StrictNotIOWrap.CompileOptions) {
+    class NotIOWrapModule extends Module()(strictNotIOWrap) {
       val io = new Bundle {
         val in = UInt(32.W).asInput
         val out = Bool().asOutput


### PR DESCRIPTION
Make it relatively easy to override a single CompileOption.