### PR TITLE
Change Enum to emit minimum widths of 1

### DIFF
--- a/src/main/scala/chisel3/util/Enum.scala
+++ b/src/main/scala/chisel3/util/Enum.scala
@@ -10,7 +10,7 @@ import chisel3._
 trait Enum {
   /** Returns a sequence of Bits subtypes with values from 0 until n. Helper method. */
   protected def createValues(n: Int): Seq[UInt] =
-    (0 until n).map(_.U(log2Ceil(n).W))
+    (0 until n).map(_.U((1 max log2Ceil(n)).W))
 
   /** Returns n unique UInt values, use with unpacking to specify an enumeration.
     *

--- a/src/test/scala/chiselTests/EnumSpec.scala
+++ b/src/test/scala/chiselTests/EnumSpec.scala
@@ -1,0 +1,19 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.util.Enum
+import chisel3.testers.BasicTester
+
+class EnumSpec extends ChiselFlatSpec {
+
+  "1-entry Enums" should "work" in {
+    assertTesterPasses(new BasicTester {
+      val onlyState :: Nil = Enum(1)
+      val wire = Wire(init = onlyState)
+      chisel3.assert(wire === onlyState)
+      stop()
+    })
+  }
+}


### PR DESCRIPTION
Fixes #554 

Tried to changed ULit to allow zero-width wires but this seems to have exposed some bugs in Firrtl so I think a workaround is fine.