### PR TITLE
Fix macOS install instructions for homebrew package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This will walk you through installing Chisel and its dependencies:
 1. Install sbt:
 
   ```
-  brew cask install sbt
+  brew install sbt
   ```
 1. Install Verilator:
 


### PR DESCRIPTION
On macOS, running `brew cask install sbt` from the install instructions results in:

   Error: No available Cask for sbt

Looks like `sbt` moved from cask to the official homebrew repository. Correct command seems to be `brew install sbt`

Check with official [sbt documentation](http://www.scala-sbt.org/download.html)