### PR TITLE
	Fix assignment from 0-entry Vec: add test

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -24,13 +24,13 @@ sealed abstract class Aggregate extends Data {
     pushCommand(BulkConnect(sourceInfo, this.lref, that.lref))
 
   override def do_asUInt(implicit sourceInfo: SourceInfo): UInt = {
-    SeqUtils.do_asUInt(getElements.map(_.asUInt()))
+    SeqUtils.do_asUInt(flatten.map(_.asUInt()))
   }
   private[core] override def connectFromBits(that: Bits)(implicit sourceInfo: SourceInfo,
       compileOptions: CompileOptions): Unit = {
     var i = 0
     val bits = Wire(UInt(this.width), init=that)  // handles width padding
-    for (x <- getElements) {
+    for (x <- flatten) {
       x.connectFromBits(bits(i + x.getWidth - 1, i))
       i += x.getWidth
     }

--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -501,7 +501,6 @@ class Bundle extends Record {
     * be one, otherwise returns None.
     */
   private def getBundleField(m: java.lang.reflect.Method): Option[Data] = m.invoke(this) match {
-    case v: Vec[_] if v.isEmpty => None
     case d: Data => Some(d)
     case Some(d: Data) => Some(d)
     case _ => None

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -144,6 +144,11 @@ class ZeroEntryVecTester extends BasicTester {
   require(0.U.asTypeOf(bundleWithZeroEntryVec).getWidth == 1)
   require(bundleWithZeroEntryVec.asUInt.getWidth == 1)
 
+  val m = Module(new Module {
+    val io = IO(Output(bundleWithZeroEntryVec.cloneType))
+  })
+  Wire(init = m.io.bar)
+
   stop()
 }
 


### PR DESCRIPTION
I attempted to fix this in 8e4ddc62db448b613ae327792e72defca4d115d4, but
that fix was incomplete, as my additional regression test shows.  Since
then I found the root cause: 375e2b6a0a456c55298d82837d28986de6211ebc
introduced a regression for bundles containing zero-entry Vecs.  Until
zero-width UInts are supported, the zero-entry Vecs need to be flattened
out before doing asUInt/asTypeOf on a bundle.  Undoing that commit's
replacement of Data.flatten with Aggregate.getElements is the best
interim fix.