### PR TITLE
Deprecate fromBits and clock/reset constructors

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -283,22 +283,6 @@ abstract class Data extends HasId {
   /** Returns Some(width) if the width is known, else None. */
   final def widthOption: Option[Int] = if (isWidthKnown) Some(getWidth) else None
 
-  /** Creates an new instance of this type, unpacking the input Bits into
-    * structured data.
-    *
-    * This performs the inverse operation of toBits.
-    *
-    * @note does NOT assign to the object this is called on, instead creates
-    * and returns a NEW object (useful in a clone-and-assign scenario)
-    * @note does NOT check bit widths, may drop bits during assignment
-    * @note what fromBits assigs to must have known widths
-    */
-  def fromBits(that: Bits)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): this.type = {
-    val output = Wire(chiselCloneType).asInstanceOf[this.type]
-    output.connectFromBits(that)
-    output
-  }
-
   /** Packs the value of this object as plain Bits.
     *
     * This performs the inverse operation of fromBits(Bits).

--- a/chiselFrontend/src/main/scala/chisel3/core/SeqUtils.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/SeqUtils.scala
@@ -70,7 +70,7 @@ private[chisel3] object SeqUtils {
 
       def buildAndOrMultiplexor[TT <: Data](inputs: Iterable[(Bool, TT)]): T = {
         val masked = for ((s, i) <- inputs) yield Mux(s, i.asUInt(), 0.U)
-        output.fromBits(masked.reduceLeft(_ | _))
+        masked.reduceLeft(_ | _).asTypeOf(output)
       }
 
       output match {
@@ -82,7 +82,7 @@ private[chisel3] object SeqUtils {
           }
 
           val masked = for ((s, i) <- sInts) yield Mux(s, i, 0.S)
-          output.fromBits(masked.reduceLeft(_ | _))
+          masked.reduceLeft(_ | _).asTypeOf(output)
 
         case _: FixedPoint =>
           val (sels, possibleOuts) = in.toSeq.unzip

--- a/chiselFrontend/src/main/scala/chisel3/core/UserModule.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/UserModule.scala
@@ -117,14 +117,27 @@ abstract class ImplicitModule(implicit moduleCompileOptions: CompileOptions)
   * IO), the clock and reset constructors will be phased out. Recommendation is to wrap the module
   * in a withClock/withReset/withClockAndReset block, or directly hook up clock or reset IO pins.
   */
-abstract class LegacyModule(
-    override_clock: Option[Clock]=None, override_reset: Option[Bool]=None)
-    (implicit moduleCompileOptions: CompileOptions)
+abstract class LegacyModule(implicit moduleCompileOptions: CompileOptions)
     extends ImplicitModule {
+  // These are to be phased out
+  protected var override_clock: Option[Clock] = None
+  protected var override_reset: Option[Bool] = None
+  
   // _clock and _reset can be clock and reset in these 2ary constructors
   // once chisel2 compatibility issues are resolved
+  @deprecated("Module constructor with override_clock and override_reset deprecated, use withClockAndReset", "chisel3")
+  def this(override_clock: Option[Clock]=None, override_reset: Option[Bool]=None)
+      (implicit moduleCompileOptions: CompileOptions) = {
+    this()
+    this.override_clock = override_clock
+    this.override_reset = override_reset
+  }
+  
+  @deprecated("Module constructor with override _clock deprecated, use withClock", "chisel3")
   def this(_clock: Clock)(implicit moduleCompileOptions: CompileOptions) = this(Option(_clock), None)(moduleCompileOptions)
+  @deprecated("Module constructor with override _reset deprecated, use withReset", "chisel3")
   def this(_reset: Bool)(implicit moduleCompileOptions: CompileOptions)  = this(None, Option(_reset))(moduleCompileOptions)
+  @deprecated("Module constructor with override _clock, _reset deprecated, use withClockAndReset", "chisel3")
   def this(_clock: Clock, _reset: Bool)(implicit moduleCompileOptions: CompileOptions) = this(Option(_clock), Option(_reset))(moduleCompileOptions)
 
   // IO for this Module. At the Scala level (pre-FIRRTL transformations),

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -37,6 +37,26 @@ package object Chisel {     // scalastyle:ignore package.object.name
   val Clock = chisel3.core.Clock
   type Clock = chisel3.core.Clock
 
+  // Implicit conversion to allow fromBits because it's being deprecated in chisel3
+  implicit class fromBitsable[T <: Data](val data: T) {
+    import chisel3.core.CompileOptions
+    import chisel3.internal.sourceinfo.SourceInfo
+    
+    /** Creates an new instance of this type, unpacking the input Bits into
+      * structured data.
+      *
+      * This performs the inverse operation of toBits.
+      *
+      * @note does NOT assign to the object this is called on, instead creates
+      * and returns a NEW object (useful in a clone-and-assign scenario)
+      * @note does NOT check bit widths, may drop bits during assignment
+      * @note what fromBits assigs to must have known widths
+      */
+    def fromBits(that: Bits)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+      that.asTypeOf(data)
+    }
+  }
+  
   type Aggregate = chisel3.core.Aggregate
   val Vec = chisel3.core.Vec
   type Vec[T <: Data] = chisel3.core.Vec[T]

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -41,7 +41,7 @@ package object Chisel {     // scalastyle:ignore package.object.name
   implicit class fromBitsable[T <: Data](val data: T) {
     import chisel3.core.CompileOptions
     import chisel3.internal.sourceinfo.SourceInfo
-    
+
     /** Creates an new instance of this type, unpacking the input Bits into
       * structured data.
       *
@@ -56,7 +56,7 @@ package object Chisel {     // scalastyle:ignore package.object.name
       that.asTypeOf(data)
     }
   }
-  
+
   type Aggregate = chisel3.core.Aggregate
   val Vec = chisel3.core.Vec
   type Vec[T <: Data] = chisel3.core.Vec[T]
@@ -175,7 +175,7 @@ package object Chisel {     // scalastyle:ignore package.object.name
   import chisel3.core.Param
   abstract class BlackBox(params: Map[String, Param] = Map.empty[String, Param]) extends chisel3.core.BlackBox(params) {
     // This class auto-wraps the BlackBox with IO(...), allowing legacy code (where IO(...) wasn't
-    // required) to build. 
+    // required) to build.
     override def _autoWrapPorts() = {
       if (!_ioPortBound()) {
         IO(io)
@@ -196,10 +196,13 @@ package object Chisel {     // scalastyle:ignore package.object.name
     // This class auto-wraps the Module IO with IO(...), allowing legacy code (where IO(...) wasn't
     // required) to build.
     // Also provides the clock / reset constructors, which were used before withClock happened.
-    
-    def this(_clock: Clock)(implicit moduleCompileOptions: CompileOptions) = this(Option(_clock), None)(moduleCompileOptions)
-    def this(_reset: Bool)(implicit moduleCompileOptions: CompileOptions)  = this(None, Option(_reset))(moduleCompileOptions)
-    def this(_clock: Clock, _reset: Bool)(implicit moduleCompileOptions: CompileOptions) = this(Option(_clock), Option(_reset))(moduleCompileOptions)
+
+    def this(_clock: Clock)(implicit moduleCompileOptions: CompileOptions) =
+      this(Option(_clock), None)(moduleCompileOptions)
+    def this(_reset: Bool)(implicit moduleCompileOptions: CompileOptions)  =
+      this(None, Option(_reset))(moduleCompileOptions)
+    def this(_clock: Clock, _reset: Bool)(implicit moduleCompileOptions: CompileOptions) =
+      this(Option(_clock), Option(_reset))(moduleCompileOptions)
 
     override def _autoWrapPorts() = {
       if (!_ioPortBound()) {
@@ -223,7 +226,7 @@ package object Chisel {     // scalastyle:ignore package.object.name
     // parameterized scope.
     def apply[T <: Data](t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
       chisel3.core.Reg(t)
-    
+
     /** Creates a register with optional next and initialization values.
       *
       * @param t: data type for the register

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -24,6 +24,16 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   val Clock = chisel3.core.Clock
   type Clock = chisel3.core.Clock
 
+  implicit class fromBitsable[T <: Data](val data: T) {
+    import chisel3.core.CompileOptions
+    import chisel3.internal.sourceinfo.SourceInfo
+
+    @deprecated("fromBits is deprecated, use asTypeOf instead", "chisel3")
+    def fromBits(that: Bits)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+      that.asTypeOf(data)
+    }
+  }
+  
   type Aggregate = chisel3.core.Aggregate
   val Vec = chisel3.core.Vec
   type Vec[T <: Data] = chisel3.core.Vec[T]

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -171,11 +171,18 @@ class QueueIO[T <: Data](gen: T, entries: Int) extends Bundle
 class Queue[T <: Data](gen: T,
                        val entries: Int,
                        pipe: Boolean = false,
-                       flow: Boolean = false,
-                       override_reset: Option[Bool] = None)
-extends Module(override_reset=override_reset) {
-  def this(gen: T, entries: Int, pipe: Boolean, flow: Boolean, _reset: Bool) =
-    this(gen, entries, pipe, flow, Some(_reset))
+                       flow: Boolean = false)
+    extends Module() {
+  @deprecated("Module constructor with override _reset deprecated, use withReset", "chisel3")
+  def this(gen: T, entries: Int, pipe: Boolean, flow: Boolean, override_reset: Option[Bool]) = {
+    this(gen, entries, pipe, flow)
+    this.override_reset = override_reset
+  }
+  @deprecated("Module constructor with override _reset deprecated, use withReset", "chisel3")
+  def this(gen: T, entries: Int, pipe: Boolean, flow: Boolean, _reset: Bool) = {
+    this(gen, entries, pipe, flow)
+    this.override_reset = Some(_reset)
+  }
 
   val io = IO(new QueueIO(gen, entries))
 

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -43,7 +43,7 @@ trait BundleSpecUtils {
     assert(uint.getWidth == 32) // elaboration time
     assert(uint === "h12345678".asUInt(32.W))
     // Back to Bundle
-    val bundle2 = (new BundleFooBar).fromBits(uint)
+    val bundle2 = uint.asTypeOf(new BundleFooBar)
     assert(0x1234.U === bundle2.foo)
     assert(0x5678.U === bundle2.bar)
     stop()

--- a/src/test/scala/chiselTests/FixedPointSpec.scala
+++ b/src/test/scala/chiselTests/FixedPointSpec.scala
@@ -32,9 +32,9 @@ class FixedPointFromBitsTester extends BasicTester {
   val sint_result = FixedPoint.fromDouble(-1.5, 4.W, 1.BP)
   val fp_result   = FixedPoint.fromDouble(1.5, 4.W, 1.BP)
 
-  val uint2fp = fp_tpe.fromBits(uint)
-  val sint2fp = fp_tpe.fromBits(sint)
-  val fp2fp   = fp_tpe.fromBits(fp)
+  val uint2fp = uint.asTypeOf(fp_tpe)
+  val sint2fp = sint.asTypeOf(fp_tpe)
+  val fp2fp   = fp.asTypeOf(fp_tpe)
 
   val uintToFp = uint.asFixedPoint(1.BP)
   val sintToFp = sint.asFixedPoint(1.BP)

--- a/src/test/scala/chiselTests/FromBitsTester.scala
+++ b/src/test/scala/chiselTests/FromBitsTester.scala
@@ -19,17 +19,17 @@ class FromBitsBundleTester extends BasicTester {
 
   val bun = new MultiTypeBundle
 
-  val bunFromBits = bun.fromBits( ((4 << 8) + (15 << 4) + (12 << 0)).U )
+  val bunFromBits = ((4 << 8) + (15 << 4) + (12 << 0)).U.asTypeOf(bun)
 
   assert(bunFromBits.u === 4.U)
   assert(bunFromBits.s === -1.S)
-  assert(bunFromBits.fp === FixedPoint.fromDouble(-0.5, width=4, binaryPoint=3))
+  assert(bunFromBits.fp === FixedPoint.fromDouble(-0.5, 4.W, 3.BP))
 
   stop()
 }
 
 class FromBitsVecTester extends BasicTester {
-  val vec = Vec(4, SInt(4.W)).fromBits( ((15 << 12) + (0 << 8) + (1 << 4) + (2 << 0)).U )
+  val vec = ((15 << 12) + (0 << 8) + (1 << 4) + (2 << 0)).U.asTypeOf(Vec(4, SInt(4.W)))
 
   assert(vec(0) === 2.S)
   assert(vec(1) === 1.S)
@@ -40,8 +40,8 @@ class FromBitsVecTester extends BasicTester {
 }
 
 class FromBitsTruncationTester extends BasicTester {
-  val truncate = UInt(3.W).fromBits( (64 + 3).U )
-  val expand   = UInt(3.W).fromBits( 1.U )
+  val truncate = (64 + 3).U.asTypeOf(UInt(3.W))
+  val expand   = 1.U.asTypeOf(UInt(3.W))
 
   assert( DataMirror.widthOf(truncate).get == 3 )
   assert( truncate === 3.U )

--- a/src/test/scala/chiselTests/ModuleExplicitResetSpec.scala
+++ b/src/test/scala/chiselTests/ModuleExplicitResetSpec.scala
@@ -19,20 +19,4 @@ class ModuleExplicitResetSpec extends ChiselFlatSpec  {
       new ModuleExplicitReset(myReset)
     }
   }
-
-  "A Module with an explicit reset in non-compatibility mode" should "elaborate" in {
-    import chisel3._
-    val myReset = true.B
-    class ModuleExplicitReset(reset: Bool) extends Module(_reset = reset) {
-      val io = IO(new Bundle {
-        val done = Output(Bool())
-      })
-
-      io.done := false.B
-    }
-
-    elaborate {
-      new ModuleExplicitReset(myReset)
-    }
-  }
 }

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -45,7 +45,7 @@ trait RecordSpecUtils {
     assert(uint.getWidth == 32) // elaboration time
     assert(uint === "hbeefdead".U)
     // Back to Record
-    val record2 = recordType.fromBits(uint)
+    val record2 = uint.asTypeOf(recordType)
     assert("hdead".U === record2("fizz").asUInt)
     assert("hbeef".U === record2("buzz").asUInt)
     stop()

--- a/src/test/scala/chiselTests/ReinterpretCast.scala
+++ b/src/test/scala/chiselTests/ReinterpretCast.scala
@@ -22,7 +22,7 @@ class AsBundleTester extends BasicTester {
 
   assert(bunFromBits.u === 4.U)
   assert(bunFromBits.s === -1.S)
-  assert(bunFromBits.fp === FixedPoint.fromDouble(-0.5, width=4, binaryPoint=3))
+  assert(bunFromBits.fp === FixedPoint.fromDouble(-0.5, 4.W, 3.BP))
 
   stop()
 }

--- a/src/test/scala/cookbook/UInt2Bundle.scala
+++ b/src/test/scala/cookbook/UInt2Bundle.scala
@@ -15,7 +15,7 @@ class UInt2Bundle extends CookbookTester(1) {
     val bar = UInt(4.W)
   }
   val uint = 0xb4.U
-  val bundle = (new MyBundle).fromBits(uint)
+  val bundle = uint.asTypeOf(new MyBundle)
   printf(p"$bundle") // Bundle(foo -> 11, bar -> 4)
 
   // Test


### PR DESCRIPTION
fromBits should be replaced with asTypeOf, clock / reset Module constructors should use withClockAndReset instead.

One breaking change is that the Queue constructor (as in `new Queue(...)`, not `Queue(...)`) no longer has the override_reset with default pipe, flow options. I don't know of any use cases of this.

Compatibility layer fromBits and clock / reset Module should continue to work without deprecation warnings.

rocket-chip appears to elaborate fine with this change.

Resolves #461, #433.
