### PR TITLE
Remove VecLike/IndexedSeq from Mem type

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Mem.scala
@@ -32,7 +32,7 @@ object Mem {
   }
 }
 
-sealed abstract class MemBase[T <: Data](t: T, val length: Int) extends HasId with VecLike[T] {
+sealed abstract class MemBase[T <: Data](t: T, val length: Int) extends HasId {
   // REVIEW TODO: make accessors (static/dynamic, read/write) combinations consistent.
 
   /** Creates a read accessor into the memory with static addressing. See the


### PR DESCRIPTION
Resolves #189 

It doesn't seem like any actual uses of Mem relied on VecLike behavior (which is to be expected - a SRAM with ridiculous ports is pretty much useless), so this is a short, sweet PR.