### PR TITLE
Update internal Pipe wiring - fixes #615

### DIFF
--- a/src/main/scala/chisel3/util/Valid.scala
+++ b/src/main/scala/chisel3/util/Valid.scala
@@ -38,8 +38,8 @@ object Pipe
   def apply[T <: Data](enqValid: Bool, enqBits: T, latency: Int)(implicit compileOptions: CompileOptions): Valid[T] = {
     if (latency == 0) {
       val out = Wire(Valid(enqBits))
-      out.valid <> enqValid
-      out.bits <> enqBits
+      out.valid := enqValid
+      out.bits := enqBits
       out
     } else {
       val v = RegNext(enqValid, false.B)

--- a/src/test/scala/chiselTests/ConnectSpec.scala
+++ b/src/test/scala/chiselTests/ConnectSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.experimental.{FixedPoint, Analog}
+import chisel3.experimental.{Analog, FixedPoint}
 import chisel3.testers.BasicTester
 
 abstract class CrossCheck extends Bundle {
@@ -17,6 +17,17 @@ class CrossConnects(inType: Data, outType: Data) extends Module {
     val out = Output(outType)
   })
   io.out := io.in
+}
+
+class PipeInternalWires extends Module {
+  import chisel3.util.Pipe
+  val io = IO(new Bundle {
+    val a = Input(Bool())
+    val b = Input(UInt(32.W))
+  })
+  val pipe = Module(new Pipe(UInt(32.W), 32))
+  pipe.io.enq.valid <> io.a
+  pipe.io.enq.bits <> io.b
 }
 
 class CrossConnectTester(inType: Data, outType: Data) extends BasicTester {
@@ -81,5 +92,8 @@ class ConnectSpec extends ChiselPropSpec {
   }
   property("SInt := Analog should fail") {
     intercept[ChiselException]{ new CrossConnectTester(SInt(16.W), Analog(16.W)) }
+  }
+  property("Pipe internal connections should succeed") {
+    elaborate( new PipeInternalWires)
   }
 }


### PR DESCRIPTION
Replace ambiguous bi-connect ("<>") with mono-connect (":=") for internal Pipe wiring.